### PR TITLE
[Feat] #19 - 네이버 지도 추가

### DIFF
--- a/apps/service/package.json
+++ b/apps/service/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.19.0",
+    "@types/navermaps": "^3.7.9",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",
     "@vitejs/plugin-react": "^4.3.4",

--- a/apps/service/src/pages/main/_components/map/MainMap.styled.ts
+++ b/apps/service/src/pages/main/_components/map/MainMap.styled.ts
@@ -1,18 +1,19 @@
 import { css } from "@emotion/react";
 
 export const getWrapper = () => css`
-  z-index: 0;
+  z-index: 1;
   width: 100%;
-
   overflow: hidden;
   animation: expandHeight 0.8s ease forwards;
+  position: absolute;
+  top: calc(13rem);
 
   @keyframes expandHeight {
     0% {
       height: 13rem;
     }
     100% {
-      height: 100vh;
+      height: calc(100vh - 13rem);
     }
   }
 `;

--- a/apps/service/src/pages/main/_components/map/MainMap.tsx
+++ b/apps/service/src/pages/main/_components/map/MainMap.tsx
@@ -1,13 +1,66 @@
+import { useState, useEffect } from "react";
 import * as S from "./MainMap.styled";
 
-const MainMap = () => {
-  return (
-    <div css={S.getWrapper}>
-      <img
-        style={{ width: "100%" }}
-        src="https://apis.map.kakao.com/ios_v2/dimScreen_off.jpeg"
-      />
-    </div>
-  );
+let mapInstance: naver.maps.Map | undefined;
+
+const loadScript = (src: string, callback: () => void) => {
+  if (document.querySelector(`script[src="${src}"]`)) {
+    callback();
+    return;
+  }
+  const script = document.createElement("script");
+  script.type = "text/javascript";
+  script.src = src;
+  script.onload = () => {
+    callback();
+  };
+  document.head.appendChild(script);
 };
+
+const MainMap = ({
+  latitude,
+  longitude,
+}: {
+  latitude: number;
+  longitude: number;
+}) => {
+  const [isScriptLoaded, setScriptLoaded] = useState(false);
+
+  useEffect(() => {
+    if (typeof window.naver !== "undefined") {
+      setScriptLoaded(true);
+    } else {
+      loadScript(
+        `https://oapi.map.naver.com/openapi/v3/maps.js?ncpKeyId=${
+          import.meta.env.VITE_NAVER_MAP_KEY
+        }`,
+        () => setScriptLoaded(true)
+      );
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isScriptLoaded) {
+      setTimeout(() => {
+        mapInstance = new naver.maps.Map("map", {
+          center: new naver.maps.LatLng(latitude, longitude),
+          zoom: 16,
+          zoomControl: true,
+          zoomControlOptions: {
+            style: naver.maps.ZoomControlStyle.SMALL,
+            position: naver.maps.Position.TOP_RIGHT,
+          },
+        });
+
+        // new naver.maps.Marker({
+        //   position: new naver.maps.LatLng(latitude, longitude),
+        //   map: mapInstance,
+        // });
+      }, 500);
+    }
+  }, [isScriptLoaded, latitude, longitude]);
+
+  return <div id="map" css={S.getWrapper}></div>;
+};
+
 export default MainMap;

--- a/apps/service/src/pages/main/_hooks/useBoothList.tsx
+++ b/apps/service/src/pages/main/_hooks/useBoothList.tsx
@@ -44,7 +44,7 @@ const useMainBoothList = () => {
     viewType === "list" ? (
       <MainBoothList booths={booths} isLoading={boothsIsLoading} />
     ) : (
-      <MainMap />
+      <MainMap latitude={37.5584809} longitude={127.0004067} />
     );
 
   return { getBoothListHeaderChildren, BoothList, currentSortBoothOption };


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용

- 네이버 지도를 추가했습니다.

## 🚨 참고 사항
네이버맵 클라이언트 키로 사용할 key랑 value notion에 공유하겠습니다.
service root에 .env 만들고 작업해주시면 됩니다!

<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷

| 구현 내용 |           375px           |    
| :-------: | :-------------------------: | 
|    GIF    | <img width="358" alt="image" src="https://github.com/user-attachments/assets/c3421942-1cee-4fe0-99ae-8b205af45426" /> | 

## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. -->

`MainMap.styled.ts`

- 줌이 안돼서 생각을 해보니, 상단 header 부분 값들을 offset 처리 해야한다고 깨달았습니다.. height 13rem 주신거 보고 했으면 됐는데, 멍청이슈로 하나하나 다 계산해서 13rem을 구했네요...ㅋㅋㅋ (30분 소요)

```typescript
import { css } from "@emotion/react";

export const getWrapper = () => css`
  z-index: 1;
  width: 100%;
  overflow: hidden;
  animation: expandHeight 0.8s ease forwards;
  position: absolute;
  top: calc(13rem);

  @keyframes expandHeight {
    0% {
      height: 13rem;
    }
    100% {
      height: calc(100vh - 13rem);
    }
  }
`;
```
- 이후 UI에 맞게 커스텀 할게요!


## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 📟 관련 이슈

- Resolved: #19 
