### PR TITLE
[Feat] #41 - Main Page Refetch Button, Navigation, BoothList API 수정

### DIFF
--- a/apps/service/src/App.tsx
+++ b/apps/service/src/App.tsx
@@ -17,7 +17,7 @@ function App() {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <TestTool />
+      {/* <TestTool /> */}
       <ReactQueryDevtools initialIsOpen={true} />
       <LinenowProvider maxWidth="540px">
         <SplashProvider>

--- a/apps/service/src/components/booth/BoothThumbnail.tsx
+++ b/apps/service/src/components/booth/BoothThumbnail.tsx
@@ -30,11 +30,11 @@ const BoothThumbnail = (props: BoothThumbnailProps) => {
       {...attributes}
     >
       {/* 이미지 */}
-      <img
+      {/* <img
         src={thumbnail}
         alt={`${name}의 대표 이미지`}
         css={S.getImageStyle("4.5rem", "0.25rem")}
-      />
+      /> */}
 
       {/* 부스정보 */}
       <Flex gap="0.5rem" direction="column" flexGrow={1}>

--- a/apps/service/src/components/booth/BoothThumbnailCompact.tsx
+++ b/apps/service/src/components/booth/BoothThumbnailCompact.tsx
@@ -27,7 +27,12 @@ const BoothThumbnailCompact = (props: BoothThumbnailCompactProps) => {
       alignItem="center"
       {...attributes}
     >
-      <Flex as="img" src={thumbnail} css={S.getImageStyle("3rem", "0.25rem")} />
+      {/* <Flex
+        as="img"
+        alt={`${name} 부스의 썸네일 사진`}
+        src={thumbnail}
+        css={S.getImageStyle("3rem", "0.25rem")}
+      /> */}
       <Flex direction="column" flexGrow={1} gap="0.25rem">
         <Label font="body2" color="blackLight">
           {name}

--- a/apps/service/src/components/refetchButton/RefetchButton.styled.ts
+++ b/apps/service/src/components/refetchButton/RefetchButton.styled.ts
@@ -1,5 +1,21 @@
-import { css } from "@emotion/react";
+import { css, keyframes } from "@emotion/react";
 
 export const getStyle = () => css`
-  padding: 1rem;
+  width: 3.25rem;
+  padding: 0;
 `;
+
+export const getSpinAnimation = () => {
+  const spin = keyframes`
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(-360deg);
+  }
+`;
+
+  return css`
+    animation: ${spin} 1s linear infinite;
+  `;
+};

--- a/apps/service/src/hooks/apis/booth.tsx
+++ b/apps/service/src/hooks/apis/booth.tsx
@@ -6,38 +6,39 @@ import { getBooths } from "@apis/domains/booth/getBooths";
 import { getBoothsCount } from "@apis/domains/booth/getBoothsCount";
 import { getBoothsWaiting } from "@apis/domains/booth/getBoothsWaiting";
 import { getBoothWaiting } from "@apis/domains/booth/getBoothWaiting";
-
-export const useGetBooth = (boothID: number) => {
-  return useQuery({
-    queryKey: ["booth", boothID],
-    queryFn: () => getBooth(boothID),
-  });
-};
+import { QUERY_KEY } from "./query";
 
 export const useGetBooths = () => {
   return useQuery({
-    queryKey: ["booths"],
+    queryKey: QUERY_KEY.BOOTHS(),
     queryFn: () => getBooths(),
   });
 };
 
 export const useGetBoothsCount = () => {
   return useQuery({
-    queryKey: ["booths_count"],
+    queryKey: QUERY_KEY.BOOTHS_COUNT(),
     queryFn: () => getBoothsCount(),
   });
 };
 
 export const useGetBoothsWaiting = () => {
   return useQuery({
-    queryKey: ["booths_waiting"],
+    queryKey: QUERY_KEY.BOOTHS_WAITING(),
     queryFn: () => getBoothsWaiting(),
+  });
+};
+
+export const useGetBooth = (boothID: number) => {
+  return useQuery({
+    queryKey: QUERY_KEY.BOOTH(boothID),
+    queryFn: () => getBooth(boothID),
   });
 };
 
 export const useGetBoothWaiting = (boothID: number) => {
   return useQuery({
-    queryKey: ["booth_waiting", boothID],
+    queryKey: QUERY_KEY.BOOTH_WAITING(boothID),
     queryFn: () => getBoothWaiting(boothID),
   });
 };

--- a/apps/service/src/hooks/apis/query.ts
+++ b/apps/service/src/hooks/apis/query.ts
@@ -1,0 +1,21 @@
+import { QueryKey } from "@tanstack/react-query";
+
+export const QUERY_KEY = {
+  // booth
+  BOOTHS: (): QueryKey => ["booths"],
+  BOOTHS_COUNT: (): QueryKey => ["booths-count"],
+  BOOTHS_WAITING: (): QueryKey => ["booths-waiting"],
+
+  BOOTH: (id: number): QueryKey => ["booth", id],
+  BOOTH_WAITING: (id: number): QueryKey => ["booth-waiting", id],
+
+  // wiaitng
+  WAITINGS: (type: "waiting" | "finished" = "waiting") => [`waitings-${type}`],
+  WAITINGS_COUNT: (): QueryKey => [`waitings-waiting-count`],
+
+  ALL_WAITINGS: (): QueryKey => ["waiting", "all"],
+  ALL_ENTERINGS: (): QueryKey => ["entering", "all"],
+
+  WAITING: (id: number): QueryKey => ["waiting", id],
+  WAITING_BOOTH: (id: number): QueryKey => ["waiting_booth", id],
+};

--- a/apps/service/src/hooks/apis/waiting.tsx
+++ b/apps/service/src/hooks/apis/waiting.tsx
@@ -11,49 +11,51 @@ import { postCancelAllEntering } from "@apis/domains/waiting/postCancelAllEnteri
 import { postCancelAllWaiting } from "@apis/domains/waiting/postCancelAllWaiting";
 import { postSelectEntering } from "@apis/domains/waiting/postSelectEntering";
 import { useToast } from "@linenow/core/hooks";
+import { QUERY_KEY } from "./query";
 
-export const useGetWaitings = (type: "waiting" | "finished") => {
+export const useGetWaitings = (type: "waiting" | "finished" = "waiting") => {
   return useQuery({
-    queryKey: ["waitings", type],
+    queryKey: QUERY_KEY.WAITINGS(type),
     queryFn: () => getWaitings(type),
   });
 };
 
 export const useGetWaitingsCount = () => {
   return useQuery({
-    queryKey: ["waitings_count"],
+    queryKey: QUERY_KEY.WAITINGS_COUNT(),
     queryFn: () => getWaitingsCount,
   });
 };
 
 export const useGetWaiting = (waitingID: number) => {
   return useQuery({
-    queryKey: ["waiting", waitingID],
+    queryKey: QUERY_KEY.WAITING(waitingID),
     queryFn: () => getWaiting(waitingID),
   });
 };
 
 export const useGetWaitingBooth = (waitingID: number) => {
   return useQuery({
-    queryKey: ["waiting_booth", waitingID],
+    queryKey: QUERY_KEY.WAITING_BOOTH(waitingID),
     queryFn: () => getWaitingBooth(waitingID),
   });
 };
 
 export const useGetCancelAllEntering = () => {
   return useQuery({
-    queryKey: ["all_entering"],
+    queryKey: QUERY_KEY.ALL_ENTERINGS(),
     queryFn: () => getCancelAllEntering(),
   });
 };
 
 export const useGetCancelAllWaiting = () => {
   return useQuery({
-    queryKey: ["all_waiting"],
+    queryKey: QUERY_KEY.ALL_WAITINGS(),
     queryFn: () => getCancelAllWaiting(),
   });
 };
 
+// post
 export const usePostCancelAllEntering = () => {
   const { presentToast } = useToast();
   const { data: waitings = [] } = useGetCancelAllEntering();

--- a/apps/service/src/pages/main/MainPage.tsx
+++ b/apps/service/src/pages/main/MainPage.tsx
@@ -1,24 +1,37 @@
-import * as S from "./MainPage.styled";
-import MainNavigation from "./_components/mainNavigation/MainNavigation";
-import { Switch, Toast } from "@linenow/core/components";
+import { QueryKey } from "@tanstack/react-query";
+
+// apis
+import { useGetBooths, useGetBoothsWaiting } from "@hooks/apis/booth";
 
 // hooks
 import useMainViewType from "@pages/main/_hooks/useMainViewType";
 import useMainBoothList from "@pages/main/_hooks/useBoothList";
 import RefetchButton from "@components/refetchButton/RefetchButton";
-
-// apis
-
-import MainBoothListHeader from "./_components/boothList/MainBoothListHeader";
 import useToastFromLocation from "@hooks/useToastFromLocation";
 
+// components
+import { Switch, Toast } from "@linenow/core/components";
+
+import * as S from "./MainPage.styled";
+import MainNavigation from "./_components/mainNavigation/MainNavigation";
+import MainBoothListHeader from "./_components/boothList/MainBoothListHeader";
+import { useGetWaitings } from "@hooks/apis/waiting";
+import { QUERY_KEY } from "@hooks/apis/query";
+
 const MainPage = () => {
+  useGetWaitings("waiting");
+  useGetBooths();
+  useGetBoothsWaiting();
+
   const { viewType, mainViewTypeSwitchProps } = useMainViewType();
   const { getBoothListHeaderChildren, BoothList } = useMainBoothList();
   const { showToast, toastMessage } = useToastFromLocation();
 
   // refetch queries
-  const queries = [["need value"]];
+  const queries: QueryKey[] = [
+    QUERY_KEY.BOOTHS_WAITING(),
+    QUERY_KEY.WAITINGS(),
+  ];
 
   return (
     <>

--- a/apps/service/src/pages/main/_components/boothList/MainBoothList.tsx
+++ b/apps/service/src/pages/main/_components/boothList/MainBoothList.tsx
@@ -11,7 +11,7 @@ const MainBoothList = () => {
 
   return (
     <div css={S.getBoothListWrapperStyle()}>
-      {booths.map((booth, index) => {
+      {booths?.map((booth, index) => {
         const isLast = index === booths.length - 1;
         const waiting = currentWaitings[booth.boothID];
 

--- a/apps/service/src/pages/main/_components/boothList/useBoothList.ts
+++ b/apps/service/src/pages/main/_components/boothList/useBoothList.ts
@@ -1,9 +1,18 @@
-import { useGetBooths, useGetBoothsWaiting } from "@hooks/apis/booth";
+import BoothThumbnailBadge from "@components/booth/BoothThumbnailBadge";
+import { QUERY_KEY } from "@hooks/apis/query";
+
 import { BoothWaiting } from "@interfaces/waiting";
+import { useQueryClient } from "@tanstack/react-query";
+
+interface Booth extends React.ComponentProps<typeof BoothThumbnailBadge> {}
 
 export const useBoothList = () => {
-  const { data: booths = [] } = useGetBooths();
-  const { data: waitings = [] } = useGetBoothsWaiting();
+  const queryClient = useQueryClient();
+
+  const booths =
+    (queryClient.getQueryData(QUERY_KEY.BOOTHS()) as Booth[]) ?? [];
+  const waitings =
+    (queryClient.getQueryData(QUERY_KEY.WAITINGS()) as BoothWaiting[]) ?? [];
 
   const currentWaitings: Record<
     number,

--- a/apps/service/src/pages/main/_components/mainNavigation/MainNavigation.styled.ts
+++ b/apps/service/src/pages/main/_components/mainNavigation/MainNavigation.styled.ts
@@ -86,6 +86,7 @@ export const getNavigationWrapper = (type: MainViewType, isFold: boolean) => {
 
     return css`
       overflow-x: hidden;
+      overflow-y: hidden;
 
       display: flex;
       flex-direction: column;

--- a/apps/service/src/pages/main/_components/mainNavigation/MainNavigation.tsx
+++ b/apps/service/src/pages/main/_components/mainNavigation/MainNavigation.tsx
@@ -1,11 +1,13 @@
 import * as S from "./MainNavigation.styled";
 import MainNavigationWaitingList from "./MainNavigationWaitingList";
-import { Label } from "@linenow/core/components";
+import { IconLabel, Label } from "@linenow/core/components";
 
 import useMainViewType from "@pages/main/_hooks/useMainViewType";
 import useMainScroll from "@pages/main/_hooks/useMainScroll";
 import useAuth from "@hooks/useAuth";
 import WaitingCardLogin from "@components/waitingCard/WaitingCardLogin";
+import MainNavigationTitleGuest from "./title/MainNavigationTitleGuest";
+import MainNavigationTitleUser from "./title/MainNavigationTitleUser";
 
 interface MainNavigationProps extends React.PropsWithChildren {}
 
@@ -16,17 +18,23 @@ const MainNavigation = (props: MainNavigationProps) => {
 
   const { isLogin } = useAuth();
 
+  const content = isLogin ? (
+    <>
+      <MainNavigationTitleUser />
+      <MainNavigationWaitingList />
+    </>
+  ) : (
+    <>
+      <MainNavigationTitleGuest />
+      <WaitingCardLogin />
+    </>
+  );
+
   return (
     <>
       <header css={S.getWrapper(viewType, isFold)}>
         {/* 상단 대기 리스트 */}
-        <div css={S.getNavigationWrapper(viewType, isFold)}>
-          <Label font="head2" color="white">
-            라인나우
-          </Label>
-
-          {isLogin ? <MainNavigationWaitingList /> : <WaitingCardLogin />}
-        </div>
+        <div css={S.getNavigationWrapper(viewType, isFold)}>{content}</div>
 
         {/* 부스 리스트 헤더 */}
         {children}

--- a/apps/service/src/pages/main/_components/mainNavigation/MainNavigation.tsx
+++ b/apps/service/src/pages/main/_components/mainNavigation/MainNavigation.tsx
@@ -1,6 +1,5 @@
 import * as S from "./MainNavigation.styled";
 import MainNavigationWaitingList from "./MainNavigationWaitingList";
-import { IconLabel, Label } from "@linenow/core/components";
 
 import useMainViewType from "@pages/main/_hooks/useMainViewType";
 import useMainScroll from "@pages/main/_hooks/useMainScroll";
@@ -8,6 +7,7 @@ import useAuth from "@hooks/useAuth";
 import WaitingCardLogin from "@components/waitingCard/WaitingCardLogin";
 import MainNavigationTitleGuest from "./title/MainNavigationTitleGuest";
 import MainNavigationTitleUser from "./title/MainNavigationTitleUser";
+import { Flex } from "@linenow/core/components";
 
 interface MainNavigationProps extends React.PropsWithChildren {}
 
@@ -18,23 +18,28 @@ const MainNavigation = (props: MainNavigationProps) => {
 
   const { isLogin } = useAuth();
 
-  const content = isLogin ? (
-    <>
-      <MainNavigationTitleUser />
-      <MainNavigationWaitingList />
-    </>
-  ) : (
-    <>
-      <MainNavigationTitleGuest />
-      <WaitingCardLogin />
-    </>
-  );
+  const Content = () =>
+    isLogin ? <MainNavigationWaitingList /> : <WaitingCardLogin />;
+  const Title = () =>
+    isLogin ? <MainNavigationTitleUser /> : <MainNavigationTitleGuest />;
 
   return (
     <>
       <header css={S.getWrapper(viewType, isFold)}>
         {/* 상단 대기 리스트 */}
-        <div css={S.getNavigationWrapper(viewType, isFold)}>{content}</div>
+
+        <div css={S.getNavigationWrapper(viewType, isFold)}>
+          <Flex
+            height="1.5rem"
+            padding="0rem 0.25rem"
+            justifyContent="space-between"
+            alignItem="center"
+          >
+            <Title />
+          </Flex>
+
+          <Content />
+        </div>
 
         {/* 부스 리스트 헤더 */}
         {children}

--- a/apps/service/src/pages/main/_components/mainNavigation/MainNavigationWaitingList.tsx
+++ b/apps/service/src/pages/main/_components/mainNavigation/MainNavigationWaitingList.tsx
@@ -4,10 +4,15 @@ import "swiper/swiper-bundle.css"; // Updated CSS import
 import WaitingCard from "@components/waitingCard/WaitingCard";
 import WaitingCardEmpty from "@components/waitingCard/WaitingCardEmpty";
 
-import { useGetWaitings } from "@hooks/apis/waiting";
+import { useQueryClient } from "@tanstack/react-query";
+import { QUERY_KEY } from "@hooks/apis/query";
 
 const MainNavigationWaitingList = () => {
-  const { data: waitings = [] } = useGetWaitings("waiting");
+  const queryClient = useQueryClient();
+  const waitings =
+    (queryClient.getQueryData(QUERY_KEY.WAITINGS()) as React.ComponentProps<
+      typeof WaitingCard
+    >[]) ?? [];
 
   if (waitings.length === 0) return <WaitingCardEmpty />;
 

--- a/apps/service/src/pages/main/_components/mainNavigation/title/MainNavigationTitleGuest.tsx
+++ b/apps/service/src/pages/main/_components/mainNavigation/title/MainNavigationTitleGuest.tsx
@@ -1,0 +1,13 @@
+import { Flex, Label } from "@linenow/core/components";
+
+const MainNavigationTitleGuest = () => {
+  return (
+    <Flex alignItem="center" height="1.5rem" padding="0rem 0.25rem">
+      <Label font="head3" color="white">
+        라인나우
+      </Label>
+    </Flex>
+  );
+};
+
+export default MainNavigationTitleGuest;

--- a/apps/service/src/pages/main/_components/mainNavigation/title/MainNavigationTitleGuest.tsx
+++ b/apps/service/src/pages/main/_components/mainNavigation/title/MainNavigationTitleGuest.tsx
@@ -1,12 +1,12 @@
-import { Flex, Label } from "@linenow/core/components";
+import { Label } from "@linenow/core/components";
 
 const MainNavigationTitleGuest = () => {
   return (
-    <Flex alignItem="center" height="1.5rem" padding="0rem 0.25rem">
+    <>
       <Label font="head3" color="white">
         라인나우
       </Label>
-    </Flex>
+    </>
   );
 };
 

--- a/apps/service/src/pages/main/_components/mainNavigation/title/MainNavigationTitleUser.tsx
+++ b/apps/service/src/pages/main/_components/mainNavigation/title/MainNavigationTitleUser.tsx
@@ -1,14 +1,14 @@
-import { useGetWaitings } from "@hooks/apis/waiting";
-import {
-  Flex,
-  Icon,
-  IconLabel,
-  Label,
-  LinkButton,
-} from "@linenow/core/components";
+// import { useGetWaitings } from "@hooks/apis/waiting";
+import { QUERY_KEY } from "@hooks/apis/query";
+import { Waiting } from "@interfaces/waiting";
+import { Icon, IconLabel, Label, LinkButton } from "@linenow/core/components";
+import { useQueryClient } from "@tanstack/react-query";
 
 const MainNavigationTitleUser = () => {
-  const { data: waitings = [] } = useGetWaitings("waiting");
+  const queryClient = useQueryClient();
+  const waitings =
+    (queryClient.getQueryData(QUERY_KEY.WAITINGS()) as Waiting[]) ?? [];
+
   return (
     <>
       <LinkButton to={`/my-waiting`}>

--- a/apps/service/src/pages/main/_components/mainNavigation/title/MainNavigationTitleUser.tsx
+++ b/apps/service/src/pages/main/_components/mainNavigation/title/MainNavigationTitleUser.tsx
@@ -1,0 +1,42 @@
+import { useGetWaitings } from "@hooks/apis/waiting";
+import {
+  Flex,
+  Icon,
+  IconLabel,
+  Label,
+  LinkButton,
+} from "@linenow/core/components";
+
+const MainNavigationTitleUser = () => {
+  const { data: waitings = [] } = useGetWaitings("waiting");
+  return (
+    <Flex
+      justifyContent="space-between"
+      alignItem="center"
+      height="1.5rem"
+      padding="0rem 0.25rem"
+    >
+      <LinkButton to={`/my-waiting`}>
+        <IconLabel
+          gap={"0.25rem"}
+          font="head3"
+          color="white"
+          icon={"right"}
+          iconPosition="right"
+          iconProps={{ color: "white", size: 16 }}
+        >
+          나의 대기
+          <Label font="head3" color="lime">
+            {waitings.length}개
+          </Label>
+        </IconLabel>
+      </LinkButton>
+
+      <LinkButton to={`/setting`}>
+        <Icon icon="setting" color="white" />
+      </LinkButton>
+    </Flex>
+  );
+};
+
+export default MainNavigationTitleUser;

--- a/apps/service/src/pages/main/_components/mainNavigation/title/MainNavigationTitleUser.tsx
+++ b/apps/service/src/pages/main/_components/mainNavigation/title/MainNavigationTitleUser.tsx
@@ -10,12 +10,7 @@ import {
 const MainNavigationTitleUser = () => {
   const { data: waitings = [] } = useGetWaitings("waiting");
   return (
-    <Flex
-      justifyContent="space-between"
-      alignItem="center"
-      height="1.5rem"
-      padding="0rem 0.25rem"
-    >
+    <>
       <LinkButton to={`/my-waiting`}>
         <IconLabel
           gap={"0.25rem"}
@@ -35,7 +30,7 @@ const MainNavigationTitleUser = () => {
       <LinkButton to={`/setting`}>
         <Icon icon="setting" color="white" />
       </LinkButton>
-    </Flex>
+    </>
   );
 };
 

--- a/apps/service/src/pages/main/_hooks/useBoothList.tsx
+++ b/apps/service/src/pages/main/_hooks/useBoothList.tsx
@@ -1,37 +1,21 @@
 import MainBoothList from "../_components/boothList/MainBoothList";
 import { Flex, Label } from "@linenow/core/components";
 
-import useSortBooths from "./useSortBooths";
 import useMainViewType from "./useMainViewType";
 import MainMap from "../_components/map/MainMap";
+import { useBoothList } from "../_components/boothList/useBoothList";
 
 const useMainBoothList = () => {
   const { viewType } = useMainViewType();
-  // booth list api
-  const {
-    // sortBoothOptions,
-    currentSortBoothOption,
-    // handleSortBoothOptionChange,
-  } = useSortBooths();
-
-  // 부스 목록 정렬 옵션 선택
-  // const BoothOptionSelect = () => (
-  //   <Select
-  //     options={sortBoothOptions}
-  //     value={currentSortBoothOption}
-  //     onChange={handleSortBoothOptionChange}
-  //   />
-  // );
+  const { booths } = useBoothList();
 
   // 고민 좀 해보기...
   const getBoothListHeaderChildren = () =>
     viewType === "list" && (
       <Flex justifyContent="space-between">
         <Label font="body3" color="gray">
-          N개의 부스
+          {booths.length}개의 부스
         </Label>
-
-        {/* <BoothOptionSelect /> */}
       </Flex>
     );
 
@@ -42,7 +26,7 @@ const useMainBoothList = () => {
       <MainMap latitude={37.5584809} longitude={127.0004067} />
     );
 
-  return { getBoothListHeaderChildren, BoothList, currentSortBoothOption };
+  return { getBoothListHeaderChildren, BoothList };
 };
 
 export default useMainBoothList;

--- a/apps/service/src/pages/myWaiting/_components/MyWaitingList.tsx
+++ b/apps/service/src/pages/myWaiting/_components/MyWaitingList.tsx
@@ -22,7 +22,7 @@ const MyWaitingList = (props: MyWaitingListProps) => {
       )}
 
       {/* 대기 목록 */}
-      {waitings.length === 0 && <div>이럴수가 아직 없어요!</div>}
+      {waitings.length === 0 && <div>EMPTY VIEW</div>}
       {waitings.map((waiting, index) => (
         <WaitingCard key={index} {...waiting} />
       ))}

--- a/apps/service/src/pages/myWaiting/_components/MyWaitingList.tsx
+++ b/apps/service/src/pages/myWaiting/_components/MyWaitingList.tsx
@@ -22,6 +22,7 @@ const MyWaitingList = (props: MyWaitingListProps) => {
       )}
 
       {/* 대기 목록 */}
+      {waitings.length === 0 && <div>이럴수가 아직 없어요!</div>}
       {waitings.map((waiting, index) => (
         <WaitingCard key={index} {...waiting} />
       ))}

--- a/apps/service/src/pages/waitingCheck/WaitingCheckPage.tsx
+++ b/apps/service/src/pages/waitingCheck/WaitingCheckPage.tsx
@@ -37,7 +37,7 @@ const WaitingCheckPage = () => {
       {isModalOpen && (
         <WaitingCheckCautionModal
           checkedPeople={checkedPeople}
-          boothID={booth.id}
+          boothID={booth.boothID}
           onClose={handleCloseModal}
         />
       )}

--- a/packages/core/src/components/buttonExtension/ButtonExtension.styled.ts
+++ b/packages/core/src/components/buttonExtension/ButtonExtension.styled.ts
@@ -3,6 +3,15 @@ import { getHoverAnimation } from "../../styles/animation";
 
 export const getAnimation = () => getHoverAnimation;
 
+export const getLinkButtonStyle = () => {
+  return css`
+    display: flex;
+
+    & svg {
+      flex-shrink: 0;
+    }
+  `;
+};
 export const getButtonStyle = () => {
   return css`
     cursor: pointer;

--- a/packages/core/src/components/buttonExtension/ButtonExtension.tsx
+++ b/packages/core/src/components/buttonExtension/ButtonExtension.tsx
@@ -11,7 +11,7 @@ interface LinkButtonProps extends React.ComponentProps<typeof Link> {
 export const LinkButton = (props: LinkButtonProps) => {
   const { to, children, disabled = false } = props;
   return (
-    <Link to={to} css={disabled || S.getAnimation()}>
+    <Link to={to} css={[S.getLinkButtonStyle, disabled || S.getAnimation()]}>
       {children}
     </Link>
   );

--- a/packages/core/src/components/flex/Flex.styled.ts
+++ b/packages/core/src/components/flex/Flex.styled.ts
@@ -8,6 +8,7 @@ export const getFlexStyle = (style: FlexStyle) => css`
 
   display: flex;
   flex-direction: ${style.direction};
+  flex-shrink: 0;
   gap: ${style.gap};
   align-items: ${style.alignItem};
   justify-content: ${style.justifyContent};

--- a/packages/core/src/components/flex/Flex.tsx
+++ b/packages/core/src/components/flex/Flex.tsx
@@ -29,6 +29,7 @@ const Flex = <T extends React.ElementType>(props: FlexProps<T>) => {
     justifyContent = "start",
     overflow = "hidden",
     padding = "0rem",
+
     ...attributes
   } = props;
 

--- a/packages/core/src/components/icon/Icon.styled.ts
+++ b/packages/core/src/components/icon/Icon.styled.ts
@@ -1,0 +1,9 @@
+import { css } from "@emotion/react";
+
+export const getContainerStyle = (size: number) => {
+  return css`
+    width: ${size}px;
+    height: ${size}px;
+    display: flex;
+  `;
+};

--- a/packages/core/src/components/icon/Icon.tsx
+++ b/packages/core/src/components/icon/Icon.tsx
@@ -1,8 +1,10 @@
+import * as S from "./Icon.styled";
+
 import { iconColors } from "../../styles/colors";
 import { IconColorKey } from "../../styles/theme";
 import { IconKey, icons } from "./icons";
 
-interface IconProps {
+interface IconProps extends React.ComponentPropsWithoutRef<"div"> {
   icon: IconKey;
   color?: IconColorKey;
   size?: number;
@@ -13,12 +15,17 @@ export interface IconAssetProps {
   size?: number;
 }
 
-const Icon = ({ icon, size = 24, color }: IconProps) => {
+const Icon = (props: IconProps) => {
+  const { icon, size = 24, color, ...attributes } = props;
   const IconComponent = icons[icon];
 
   if (!IconComponent) return;
 
-  return <IconComponent size={size} color={color && iconColors[color]} />;
+  return (
+    <div css={[S.getContainerStyle(size)]} {...attributes}>
+      <IconComponent size={size} color={color && iconColors[color]} />
+    </div>
+  );
 };
 
 export default Icon;


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용

- Main Page의 작은 요소들을 수정했습니다.
- 새로고침 버튼, 네비게이션, 부스 리스트 의 에이피아이 관리 로직을 변경했습니다.

## 🚨 참고 사항

<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷

| 구현 내용 |           Desktop           |            390px            |            320px            |
| :-------: | :-------------------------: | :-------------------------: | :-------------------------: |
|    GIF    | <img src = "" width ="250"> | <img src = "" width ="250"> | <img src = "" width ="250"> |

## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. -->

`HomeView`

- 쏼라쏼라

```typescript

const MainPage = () => {
  useGetWaitings("waiting");
  useGetBooths();
  useGetBoothsWaiting();

  const { viewType, mainViewTypeSwitchProps } = useMainViewType();
  const { getBoothListHeaderChildren, BoothList } = useMainBoothList();
  const { showToast, toastMessage } = useToastFromLocation();

  // refetch queries
  const queries: QueryKey[] = [
    QUERY_KEY.BOOTHS_WAITING(),
    QUERY_KEY.WAITINGS(),
  ];

... 생략
```
메인 페이지가 마운트될 때 필요한 API를 호출합니다.
해당 API의 데이터가 필요한 경우 아래 예시처럼 캐싱된 데이터를 가져와 활용합니다.

```ts
const MainNavigationTitleUser = () => {
  const queryClient = useQueryClient();
  const waitings =
    (queryClient.getQueryData(QUERY_KEY.WAITINGS()) as Waiting[]) ?? [];

```

## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 📟 관련 이슈

- Resolved: #41
