### PR TITLE
[Feat]#20-관리자 페이지 소켓 및 대기 상태 조회

### DIFF
--- a/apps/admin/src/apis/domains/booth/apis.ts
+++ b/apps/admin/src/apis/domains/booth/apis.ts
@@ -15,7 +15,7 @@ export const getWaitings = async (
 ): Promise<Waiting[]> => {
   const response = await getResponse<GetWaitingsResponse>(
     status != undefined
-      ? `/api/v1/manager/waitings?status=${status}`
+      ? `/api/v1/manager/booth/${status}`
       : `/api/v1/manager/booth`
   );
   return response ? transformGetWaitingsResponse(response) : [];

--- a/apps/admin/src/apis/domains/boothManaging/_interfaces.ts
+++ b/apps/admin/src/apis/domains/boothManaging/_interfaces.ts
@@ -5,11 +5,11 @@ export interface PostWaitingsActionRequest {
   action: ManagerActionStatus;
 }
 
-export interface GetWaitingCountsResponse {
-  waiting: number;
-  calling: number;
-  arrived: number;
-  canceled: number;
+export interface BoothInfo {
+  canceled_team_cnt: number;
+  entered_team_cnt: number;
+  entering_team_cnt: number;
+  waiting_team_cnt: number;
 }
 export interface GetBoothStatus {
   id: number;

--- a/apps/admin/src/apis/domains/boothManaging/apis.ts
+++ b/apps/admin/src/apis/domains/boothManaging/apis.ts
@@ -1,6 +1,6 @@
 import {
   GetBoothStatus,
-  GetWaitingCountsResponse,
+  BoothInfo,
   PostBoothStatusRequest,
   transtromGetBoothStatus,
 } from "@apis/domains/boothManaging/_interfaces";
@@ -10,8 +10,8 @@ import { Booth } from "@interfaces/booth";
 
 export const getWaitingsCounts = async () => {
   try {
-    const response = getResponse<GetWaitingCountsResponse>(
-      `/api/v1/manager/waiting-counts`
+    const response = getResponse<BoothInfo>(
+      `/api/v1/manager/booth/status-count`
     );
     return response;
   } catch (error) {

--- a/apps/admin/src/atoms/auth.ts
+++ b/apps/admin/src/atoms/auth.ts
@@ -29,10 +29,11 @@ const getLocalStorageTokens = (): AuthProps | null => {
   return null;
 };
 
-export const authAtom = atom<AuthState>(undefined);
+// export const authAtom = atom<AuthState>(undefined);
+export const authAtom = atom<AuthState>(getLocalStorageTokens());
 
 // 마운트 시 localStorage에서 user 정보 가져옴
-authAtom.onMount = (set) => {
-  const tokens = getLocalStorageTokens();
-  set(tokens);
-};
+// authAtom.onMount = (set) => {
+//   const tokens = getLocalStorageTokens();
+//   set(tokens);
+// };

--- a/apps/admin/src/atoms/boothInfo.ts
+++ b/apps/admin/src/atoms/boothInfo.ts
@@ -5,7 +5,7 @@ const initialBoothInfo: Booth = {
   // Booth 인터페이스에 필요한 초기 값 지정
   boothID: 0,
   name: "",
-  status: "finished",
+  status: "paused",
 };
 
 export const BoothInfoAtom = atom<Booth>(initialBoothInfo);

--- a/apps/admin/src/components/sidebar/Sidebar.tsx
+++ b/apps/admin/src/components/sidebar/Sidebar.tsx
@@ -165,7 +165,7 @@ const Sidebar = ({ isMobile, isOpen, setIsOpen }: SidebarProps) => {
     <>
       <S.SidebarWrapper>
         <S.SidebarUserInfoWapper>
-          {isLoading ? (
+          {auth === undefined || null ? (
             <Spinner />
           ) : (
             <>

--- a/apps/admin/src/hooks/useSocket.ts
+++ b/apps/admin/src/hooks/useSocket.ts
@@ -1,0 +1,56 @@
+import { useAtomValue } from "jotai";
+import { authAtom } from "@atoms/auth";
+import { useEffect, useRef } from "react";
+
+const useWebSocket = (onMessageCallback: (message: any) => void) => {
+  const auth = useAtomValue(authAtom);
+  const socketRef = useRef<WebSocket | null>(null);
+
+  useEffect(() => {
+    const token = localStorage.getItem("accessToken");
+    const boothId = auth?.adminUser?.booth_id;
+    const baseSocketUrl = import.meta.env.VITE_BASE_SOCKET_URL;
+
+    if (!token || !boothId) {
+      console.log("토큰 또는 부스 아이디 없음");
+      return;
+    }
+
+    const socket = new WebSocket(
+      `${baseSocketUrl}/ws/waiting/${boothId}?token=${token}`
+    );
+
+    socket.onopen = () => {
+      console.log("WebSocket 연결됨");
+    };
+
+    socket.onmessage = (event) => {
+      console.log("받은 메시지:", event.data);
+      try {
+        const data = JSON.parse(event.data);
+        console.log("파싱된 데이터:", data);
+        onMessageCallback?.(data);
+      } catch (error) {
+        console.error("JSON 파싱 실패:", error);
+      }
+    };
+
+    socket.onerror = (error) => {
+      console.error("WebSocket 에러:", error);
+    };
+
+    socket.onclose = () => {
+      console.log("WebSocket 연결 종료");
+    };
+
+    // cleanup
+    return () => {
+      socket.close();
+      console.log("웹소켓 종료");
+    };
+  }, [auth, onMessageCallback]);
+
+  return socketRef;
+};
+
+export default useWebSocket;

--- a/apps/admin/src/lib/types/status.ts
+++ b/apps/admin/src/lib/types/status.ts
@@ -11,8 +11,8 @@ export type ManagerActionStatus = "call" | "confirm" | "cancel";
 export type BoothStatus = "operating" | "paused";
 
 export type WaitingStatusParams =
-  | "calling"
+  | "entering"
   | "waiting"
-  | "arrived"
+  | "entered"
   | "canceled"
   | undefined;

--- a/apps/admin/src/pages/main/MainPages.tsx
+++ b/apps/admin/src/pages/main/MainPages.tsx
@@ -33,9 +33,9 @@ const MainPage = () => {
       case "대기 중":
         return "waiting";
       case "호출 중":
-        return "calling";
+        return "entering";
       case "입장 완료":
-        return "arrived";
+        return "entered";
       case "대기 취소":
         return "canceled";
       default:

--- a/apps/admin/src/pages/main/MainPages.tsx
+++ b/apps/admin/src/pages/main/MainPages.tsx
@@ -6,10 +6,14 @@ import TagList from "./_components/tag/TagList";
 import Spinner from "@components/spinner/Spinner";
 import { WaitingStatusParams } from "@linenow-types/status";
 import { useGetWaitingsCounts } from "@hooks/apis/boothManaging";
+import useWebSocket from "@hooks/useSocket";
+import { Waiting } from "@interfaces/waiting";
+import { transformGetWaitingResponse } from "@apis/domains/booth/_interfaces";
 
 const MainPage = () => {
   const { data: waitingsCounts } = useGetWaitingsCounts();
   const [selectedTag, setSelectedTag] = useState<string>("전체보기");
+  const [waitings, setWaitings] = useState<Waiting[]>([]);
 
   const getStatus = (tag: string): WaitingStatusParams => {
     switch (tag) {
@@ -26,14 +30,46 @@ const MainPage = () => {
     }
   };
 
+  //웹소켓 연결
+  const handleWebSocketMessage = (message: any) => {
+    const status = message?.data?.waiting_status;
+    console.log("status", status);
+    const updatedWaiting = transformGetWaitingResponse(message?.data);
+    console.log("update", updatedWaiting);
+
+    // 사용자가 대기 건 경우
+    setWaitings((prevWaitings) => {
+      if (status === "waiting") {
+        return [...prevWaitings, updatedWaiting];
+      }
+
+      // 대기 취소된 경우
+      if (status === "canceled") {
+        return prevWaitings.map((waiting) =>
+          waiting.waitingID === updatedWaiting.waitingID
+            ? { ...waiting, waitingStatus: "canceled" }
+            : waiting
+        );
+      }
+
+      return prevWaitings;
+    });
+  };
+
+  useWebSocket(handleWebSocketMessage);
+
   // API hooks
-  const { data: waitings, isLoading } = useGetWaitings(getStatus(selectedTag));
+  const { data, isLoading } = useGetWaitings(getStatus(selectedTag));
 
   const handleTagClick = (tag: string) => {
     setSelectedTag(tag);
   };
 
-  useEffect(() => {}, []);
+  useEffect(() => {
+    if (data) {
+      setWaitings(data);
+    }
+  }, [data]);
 
   if (isLoading) {
     return (

--- a/apps/admin/src/pages/main/MainPages.tsx
+++ b/apps/admin/src/pages/main/MainPages.tsx
@@ -10,10 +10,23 @@ import useWebSocket from "@hooks/useSocket";
 import { Waiting } from "@interfaces/waiting";
 import { transformGetWaitingResponse } from "@apis/domains/booth/_interfaces";
 
+interface BoothInfo {
+  waiting_team_cnt: number;
+  entering_team_cnt: number;
+  entered_team_cnt: number;
+  canceled_team_cnt: number;
+}
+
 const MainPage = () => {
   const { data: waitingsCounts } = useGetWaitingsCounts();
   const [selectedTag, setSelectedTag] = useState<string>("전체보기");
   const [waitings, setWaitings] = useState<Waiting[]>([]);
+  const [boothInfo, setBoothInfo] = useState<BoothInfo>({
+    waiting_team_cnt: 0,
+    entering_team_cnt: 0,
+    entered_team_cnt: 0,
+    canceled_team_cnt: 0,
+  });
 
   const getStatus = (tag: string): WaitingStatusParams => {
     switch (tag) {
@@ -54,6 +67,17 @@ const MainPage = () => {
 
       return prevWaitings;
     });
+
+    //부스 정보 소켓
+    const boothInfo = message?.data?.booth_info;
+    if (boothInfo) {
+      setBoothInfo((_) => ({
+        waiting_team_cnt: boothInfo.waiting_team_cnt,
+        entering_team_cnt: boothInfo.entering_team_cnt,
+        entered_team_cnt: boothInfo.entered_team_cnt,
+        canceled_team_cnt: boothInfo.canceled_team_cnt,
+      }));
+    }
   };
 
   useWebSocket(handleWebSocketMessage);
@@ -84,6 +108,10 @@ const MainPage = () => {
         selectedTag={selectedTag}
         onTagClick={handleTagClick}
         {...waitingsCounts}
+        waiting={boothInfo.waiting_team_cnt}
+        calling={boothInfo.entering_team_cnt}
+        arrived={boothInfo.entered_team_cnt}
+        canceled={boothInfo.canceled_team_cnt}
       />
 
       {waitings && waitings.length > 0 ? (

--- a/apps/admin/src/pages/main/_components/tag/TagList.tsx
+++ b/apps/admin/src/pages/main/_components/tag/TagList.tsx
@@ -15,7 +15,14 @@ interface TagListProps {
   canceled?: number;
 }
 
-const TagList = ({ selectedTag, onTagClick, ...props }: TagListProps) => {
+const TagList = ({
+  selectedTag,
+  onTagClick,
+  waiting,
+  calling,
+  arrived,
+  canceled,
+}: TagListProps) => {
   const handleRefresh = () => {
     window.location.reload();
   };
@@ -30,23 +37,23 @@ const TagList = ({ selectedTag, onTagClick, ...props }: TagListProps) => {
         />
         <Tag
           imageUrl="/images/tag_white.png"
-          label={`대기 중 ${props.waiting}팀`}
+          label={`대기 중 ${waiting}팀`}
           isSelected={selectedTag === "대기 중"}
           onClick={() => onTagClick("대기 중")}
         />
         <Tag
           imageUrl="/images/tag_green.png"
-          label={`호출 중 ${props.calling}팀`}
+          label={`호출 중 ${calling}팀`}
           isSelected={selectedTag === "호출 중"}
           onClick={() => onTagClick("호출 중")}
         />
         <Tag
-          label={`입장 완료 ${props.arrived}팀`}
+          label={`입장 완료 ${arrived}팀`}
           isSelected={selectedTag === "입장 완료"}
           onClick={() => onTagClick("입장 완료")}
         />
         <Tag
-          label={`대기 취소 ${props.canceled}팀`}
+          label={`대기 취소 ${canceled}팀`}
           isSelected={selectedTag === "대기 취소"}
           onClick={() => onTagClick("대기 취소")}
         />


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용

<!-- 작업한 내용을 적어주세요. -->
- 사용자의 대기 걸기, 대기 신청에 따른 웹소켓 연결 -> ui 즉시 반영
- 대기 상태 (대기 중, 호출 중~~) api/web socket으로 불러옵니다. 소켓으로 불러오면 바로 반영은 되는데 새로고침하면 사라져서 api get도 필요합니다!
- 대기 상태 태그 누르면 관련 api를 호출해 카드 불러오는 api 연결했습니다.

## 🚨 참고 사항

<!-- 참고할 사항이 있다면 적어주세요. -->
- 코드 so dirty.. 근데 ... 웹소켓 잘 안해봤던거라 ... 분리하면 에러떠서 일단 냅두는 중입니다.. ㅜ
- web socket url 노션 env 쪽에 적어놨습니당 추가 필요!!

## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. -->

`Mainpages`

- useSocket 훅을 만들었고, 그걸 활용해 웹소켓으로 받아오는 Message로 대기 상태 처리를 합니다. 이때 waiting_status로 상태 처리를 했습니다!

```typescript
//웹소켓 연결
  const handleWebSocketMessage = (message: any) => {
    const status = message?.data?.waiting_status;
    console.log("status", status);
    const updatedWaiting = transformGetWaitingResponse(message?.data);
    console.log("update", updatedWaiting);

    // 사용자가 대기 건 경우
    setWaitings((prevWaitings) => {
      if (status === "waiting") {
        return [...prevWaitings, updatedWaiting];
      }

      // 대기 취소된 경우
      if (status === "canceled") {
        return prevWaitings.map((waiting) =>
          waiting.waitingID === updatedWaiting.waitingID
            ? { ...waiting, waitingStatus: "canceled" }
            : waiting
        );
      }

      return prevWaitings;
    });
```

## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 📟 관련 이슈

- Resolved: #20
