### PR TITLE
[Fix] #60 - 1차 FE QA 사항 (세호)

### DIFF
--- a/apps/service/src/components/boothLocationMap/BoothLocationMap.styled.ts
+++ b/apps/service/src/components/boothLocationMap/BoothLocationMap.styled.ts
@@ -1,0 +1,62 @@
+import { fonts } from "@linenow/core/styles";
+import styled from "@emotion/styled";
+
+export const BoothLocationMapWrapper = styled.section`
+  ${fonts.head3}
+  padding: 1.25rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`;
+
+export const BoothLocationMap = styled.div`
+  /* 지도 높이는 고정으로 생각해서 하단처럼 지정합니다! */
+  position: relative;
+  height: 12.5rem;
+  width: 100%;
+  border-radius: 0.5rem;
+  border: 1px solid ${({ theme }) => theme.borderColors.gray};
+`;
+
+export const BoothLocationMapClickableBar = styled.div`
+  position: absolute;
+
+  width: 100%;
+  bottom: 0;
+  padding: 0.5rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 0 0 0.5rem 0.5rem;
+
+  z-index: 2;
+
+  color: ${({ theme }) => theme.fontColors.blackLight};
+  background-color: ${({ theme }) => theme.backgroundColors.white};
+  opacity: 0.8;
+
+  ${fonts.caption};
+
+  cursor: pointer;
+`;
+
+export const BoothLocationMapLocationWrapper = styled.div`
+  width: 100%;
+
+  display: flex;
+  justify-content: space-between;
+
+  padding-bottom: 0.5rem;
+
+  ${fonts.body2}
+`;
+
+export const BoothLocationMapLocationCopyWrapper = styled.div`
+  display: flex;
+  gap: 0.25rem;
+
+  color: ${({ theme }) => theme.fontColors.blackLight};
+  ${fonts.chip}
+
+  cursor: pointer;
+`;

--- a/apps/service/src/components/boothLocationMap/BoothLocationMap.tsx
+++ b/apps/service/src/components/boothLocationMap/BoothLocationMap.tsx
@@ -1,0 +1,50 @@
+import { useRef } from "react";
+import * as S from "./BoothLocationMap.styled";
+import { Booth } from "@interfaces/booth";
+import { useSmallNaverMap } from "@hooks/useSmallNaverMap";
+import { useNavigate } from "react-router-dom";
+import useMainViewType from "@pages/main/_hooks/useMainViewType";
+import { Icon } from "@linenow/core/components";
+import { useToast } from "@linenow/core/hooks";
+
+interface BoothLocationContentProps {
+  booth: Booth;
+}
+
+export const BoothLocationMap = ({ booth }: BoothLocationContentProps) => {
+  const mapRef = useRef<null | HTMLDivElement>(null);
+  const navigate = useNavigate();
+  const { setViewType } = useMainViewType();
+
+  const { presentToast } = useToast();
+  useSmallNaverMap(mapRef, booth);
+  return (
+    <S.BoothLocationMapWrapper>
+      부스 위치
+      <S.BoothLocationMap ref={mapRef}>
+        <S.BoothLocationMapClickableBar
+          onClick={() => {
+            setViewType("map");
+            navigate("/");
+          }}
+        >
+          클릭해서 지도 보기
+        </S.BoothLocationMapClickableBar>
+      </S.BoothLocationMap>
+      <S.BoothLocationMapLocationWrapper>
+        {booth.location}
+        <S.BoothLocationMapLocationCopyWrapper
+          onClick={() => {
+            if (booth.location) {
+              navigator.clipboard.writeText(booth.location);
+              presentToast("복사 완료");
+            }
+          }}
+        >
+          <Icon icon="copy" color="gray" size={16} />
+          위치복사
+        </S.BoothLocationMapLocationCopyWrapper>
+      </S.BoothLocationMapLocationWrapper>
+    </S.BoothLocationMapWrapper>
+  );
+};

--- a/apps/service/src/hooks/useSmallNaverMap.tsx
+++ b/apps/service/src/hooks/useSmallNaverMap.tsx
@@ -1,0 +1,82 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createRoot } from "react-dom/client";
+
+import { loadScript } from "@utils/loadScript";
+
+import { Booth } from "@interfaces/booth";
+import FocusPin from "@pages/main/_components/map/pin/FocusPin";
+
+export interface BoothPinProps
+  extends Pick<Booth, "boothID" | "longitude" | "latitude"> {}
+
+export const useSmallNaverMap = (
+  mapRef: React.RefObject<HTMLDivElement | null>,
+  booth: BoothPinProps
+) => {
+  const mapInstanceRef = useRef<naver.maps.Map | null>(null);
+  const [isMapReady, setIsMapReady] = useState<boolean>(false);
+
+  // 마커 렌더 함수 캐싱
+  const renderMarkerIcon = useCallback(() => {
+    const Pin = <FocusPin />;
+    const container = document.createElement("div");
+    createRoot(container).render(Pin);
+    return container;
+  }, []);
+
+  // 지도 1회 초기화
+  useEffect(() => {
+    if (isMapReady) return;
+
+    loadScript(
+      `https://oapi.map.naver.com/openapi/v3/maps.js?ncpKeyId=${
+        import.meta.env.VITE_NAVER_MAP_KEY
+      }`,
+      () => {
+        if (!window.naver) return;
+        const { naver } = window;
+        if (mapRef.current && window) {
+          const now = new naver.maps.LatLng(
+            Number(booth.latitude),
+            Number(booth.longitude)
+          );
+          const map = new naver.maps.Map(mapRef.current, {
+            center: now,
+            zoom: 18,
+            zoomControl: true,
+            zoomControlOptions: {
+              style: window.naver.maps.ZoomControlStyle.SMALL,
+              position: window.naver.maps.Position.TOP_RIGHT,
+            },
+          });
+          mapInstanceRef.current = map;
+          setIsMapReady(true);
+        }
+      }
+    );
+  }, []);
+
+  // 마커 업데이트만 분리 (지도 유지)
+  useEffect(() => {
+    if (!isMapReady) return;
+
+    const map = mapInstanceRef.current;
+
+    if (!map || !booth) return;
+
+    const marker = new window.naver.maps.Marker({
+      position: new window.naver.maps.LatLng(
+        Number(booth.latitude),
+        Number(booth.longitude)
+      ),
+      map,
+      icon: {
+        content: renderMarkerIcon(),
+      },
+    });
+
+    window.naver.maps.Event.addListener(marker, "click", () => {
+      map.panTo(marker.getPosition());
+    });
+  }, [isMapReady]);
+};

--- a/apps/service/src/pages/boothDetail/BoothDetailPage.tsx
+++ b/apps/service/src/pages/boothDetail/BoothDetailPage.tsx
@@ -20,6 +20,7 @@ import { useBottomSheet, useModal } from "@linenow/core/hooks";
 import LoginBottomSheetContent from "@components/bottomSheet/login/LoginBottomSheetContent";
 import { useGetBooth, useGetBoothWaiting } from "@hooks/apis/booth";
 import { useModalCancelWaiting } from "@components/modal/waiting";
+import { BoothLocationMap } from "@components/boothLocationMap/BoothLocationMap";
 
 const BoothDetailPage = () => {
   const { isLogin } = useAuth();
@@ -128,6 +129,11 @@ const BoothDetailPage = () => {
             <BoothDetailNotice booth={booth} />
           </Flex>
           <Separator height={8} />
+
+          <BoothLocationMap booth={booth} />
+
+          <Separator height={8} />
+
           <BoothDetailMenu booth={booth} />
 
           <BottomButton


### PR DESCRIPTION
# 🔥 Pull requests

## 1차 FE QA 시 누락된 상세페이지 내 Map Component를 구현했습니다.

<!-- 작업한 내용을 적어주세요. -->

## 🚨 참고 사항

<!-- 참고할 사항이 있다면 적어주세요. -->

## 📸 스크린샷

| 구현 내용 |           Desktop           |            330px            |   
| :-------: | :-------------------------: | :-------------------------: |
|    GIF    | <img src = "https://github.com/user-attachments/assets/a2e0fd41-b812-458a-a17f-249b1b3368cd" width ="250"> | <img src = "https://github.com/user-attachments/assets/e7b81fc3-ec8b-4f8b-b407-64b17faa7edb" width ="250"> |

## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. -->

`BoothDetailPage`

- BoothLocationMap이라는 Common Component화 시켰습니다. 다른 뷰에서 추가로 필요하면 아래와 같이 `Booth` type 인자를 props로 넘겨서 사용하면 됩니다!

```typescript
<BoothLocationMap booth={booth} />
```

## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 📟 관련 이슈

- Resolved: #60 
