### PR TITLE
[Fix] #56 - 1차 FE QA 사항 (서현) + 입장 취소 바텀시트

### DIFF
--- a/apps/service/src/App.tsx
+++ b/apps/service/src/App.tsx
@@ -9,14 +9,14 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 //components
 import { LinenowProvider } from "@linenow/core/components";
 import { SplashProvider } from "@pages/waitingCheck/_components/splash/SplashContext";
-import EnteringBottomsheetProvider from "@components/bottomSheet/entering/EnteringBottohSheetProvider";
+import TestTool from "@components/test/TestTool";
 
 function App() {
   const queryClient = new QueryClient();
 
   return (
     <QueryClientProvider client={queryClient}>
-      {/* <TestTool /> */}
+      <TestTool />
       <ReactQueryDevtools initialIsOpen={true} />
       <LinenowProvider maxWidth="540px">
         <SplashProvider>

--- a/apps/service/src/App.tsx
+++ b/apps/service/src/App.tsx
@@ -9,6 +9,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 //components
 import { LinenowProvider } from "@linenow/core/components";
 import { SplashProvider } from "@pages/waitingCheck/_components/splash/SplashContext";
+import EnteringBottomsheetProvider from "@components/bottomSheet/entering/EnteringBottohSheetProvider";
 
 function App() {
   const queryClient = new QueryClient();

--- a/apps/service/src/components/booth/BoothThumbnailCompact.tsx
+++ b/apps/service/src/components/booth/BoothThumbnailCompact.tsx
@@ -29,6 +29,7 @@ const BoothThumbnailCompact = (props: BoothThumbnailCompactProps) => {
       gap="0.5rem"
       width="100%"
       alignItem="center"
+      flexShrink={1}
       {...attributes}
     >
       <Flex

--- a/apps/service/src/components/bottomSheet/cancel/CancelBottomSheet.tsx
+++ b/apps/service/src/components/bottomSheet/cancel/CancelBottomSheet.tsx
@@ -1,0 +1,49 @@
+import { Button, ButtonLayout, Label } from "@linenow/core/components";
+import * as S from "../BottomSheetContent.styled";
+
+import { useBottomSheet } from "@linenow/core/hooks";
+import WaitingCard from "@components/waitingCard/WaitingCard";
+import { Waiting } from "@interfaces/waiting";
+
+interface CancelBottomSheetContentProps
+  extends React.ComponentProps<typeof WaitingCard>,
+    Pick<Waiting, "canceledAt"> {}
+
+const CancelBottomSheetContent = (props: CancelBottomSheetContentProps) => {
+  const { canceledAt = "", ...waiting } = props;
+  const { closeBottomSheet } = useBottomSheet();
+
+  const getCanceledString = () => {
+    const trimmed = canceledAt.slice(0, 19);
+    const date = new Date(trimmed);
+
+    const formatted = `${date.getFullYear()}년 ${
+      date.getMonth() + 1
+    }월 ${date.getDate()}일 ${date.getHours()}시 ${date.getMinutes()}분`;
+    return formatted;
+  };
+  return (
+    <S.BottomSheetContentWrapper>
+      {/* 타이틀 */}
+      <S.BottomSheetTitleWrapper>
+        <Label font="head1" color="black">
+          대기가 취소되었어요.
+        </Label>
+        <Label font="body1" color="blackLight">
+          {getCanceledString()} 부스 대기가 취소되었어요.
+        </Label>
+      </S.BottomSheetTitleWrapper>
+
+      <WaitingCard {...waiting} isOpacity={false} />
+
+      {/* 버튼 */}
+      <ButtonLayout colCount={1}>
+        <Button onClick={closeBottomSheet} variant="outline">
+          확인했어요.
+        </Button>
+      </ButtonLayout>
+    </S.BottomSheetContentWrapper>
+  );
+};
+
+export default CancelBottomSheetContent;

--- a/apps/service/src/components/bottomSheet/entering/EnteringBottohSheetProvider.tsx
+++ b/apps/service/src/components/bottomSheet/entering/EnteringBottohSheetProvider.tsx
@@ -1,0 +1,27 @@
+import useEntering from "@hooks/useEntering";
+import { BottomSheet, FixedContainer } from "@linenow/core/components";
+
+import EnteringContent from "./EnteringContent";
+import { css } from "@emotion/react";
+
+const EnteringBottomsheetProvider = () => {
+  const { isOpen, closeBottomSheet, waitings, enterings } = useEntering();
+
+  return (
+    <FixedContainer
+      css={[
+        css`
+          display: ${isOpen ? "flex" : "none"};
+        `,
+      ]}
+      zIndex={10}
+      closeContainer={closeBottomSheet}
+    >
+      <BottomSheet>
+        <EnteringContent enterings={enterings} waitings={waitings} />
+      </BottomSheet>
+    </FixedContainer>
+  );
+};
+
+export default EnteringBottomsheetProvider;

--- a/apps/service/src/components/bottomSheet/entering/EnteringContent.tsx
+++ b/apps/service/src/components/bottomSheet/entering/EnteringContent.tsx
@@ -9,6 +9,8 @@ interface Props {
 }
 
 const EnteringContent = ({ enterings, waitings }: Props) => {
+  if (enterings.length === 0) return;
+
   const isSingleEntering = enterings.length === 1;
 
   if (isSingleEntering) {

--- a/apps/service/src/components/bottomSheet/entering/EnteringContent.tsx
+++ b/apps/service/src/components/bottomSheet/entering/EnteringContent.tsx
@@ -1,13 +1,14 @@
 import BoothCard from "@components/bottomSheet/entering/boothList/BoothCard";
 import SingleEnteringContent from "./SingleEnteringContent";
 import MultipleEnteringContent from "./MultipleEnteringContent";
+import React from "react";
 
 interface Props {
   enterings: React.ComponentProps<typeof BoothCard>[];
   waitings: React.ComponentProps<typeof BoothCard>[];
 }
 
-const useEnteringContent = ({ enterings, waitings }: Props) => {
+const EnteringContent = ({ enterings, waitings }: Props) => {
   const isSingleEntering = enterings.length === 1;
 
   if (isSingleEntering) {
@@ -23,4 +24,18 @@ const useEnteringContent = ({ enterings, waitings }: Props) => {
   return <MultipleEnteringContent enterings={enterings} waitings={waitings} />;
 };
 
-export default useEnteringContent;
+export default React.memo(EnteringContent, (prevProps, nextProps) => {
+  const sameEnterings =
+    prevProps.enterings.length === nextProps.enterings.length &&
+    prevProps.enterings.every(
+      (e, i) => e.waitingID === nextProps.enterings[i].waitingID
+    );
+
+  const sameWaitings =
+    prevProps.waitings.length === nextProps.waitings.length &&
+    prevProps.waitings.every(
+      (w, i) => w.waitingID === nextProps.waitings[i].waitingID
+    );
+
+  return sameEnterings && sameWaitings;
+});

--- a/apps/service/src/components/bottomSheet/entering/boothList/BoothCard.tsx
+++ b/apps/service/src/components/bottomSheet/entering/boothList/BoothCard.tsx
@@ -5,6 +5,7 @@ import { Chip, Flex } from "@linenow/core/components";
 import EnteringChip from "./EnteringChip";
 import { useModal } from "@linenow/core/hooks";
 import { useModalConfirmEntering } from "@components/modal/waiting";
+import { css } from "@emotion/react";
 
 interface BoothCardProps
   extends Partial<
@@ -36,6 +37,11 @@ const BoothCard = (props: BoothCardProps) => {
       width="100%"
       alignItem="center"
       onClick={onClick}
+      css={[
+        css`
+          opacity: ${waitingStatus === "waiting" ? 0.3 : 1};
+        `,
+      ]}
     >
       <BoothThumbnailCompact isRightIconVisible={false} {...booth} />
       {waitingStatus === "waiting" && (

--- a/apps/service/src/components/test/TestTool.tsx
+++ b/apps/service/src/components/test/TestTool.tsx
@@ -1,0 +1,56 @@
+import CancelBottomSheetContent from "@components/bottomSheet/cancel/CancelBottomSheet";
+import styled from "@emotion/styled";
+import { useBottomSheet } from "@linenow/core/hooks";
+
+const TestTool = () => {
+  const { openBottomSheet } = useBottomSheet();
+  const openCancelBottomSheet = () => {
+    openBottomSheet({
+      children: (
+        <CancelBottomSheetContent
+          waitingID={1}
+          waitingStatus={"time_over"}
+          waitingTeamsAhead={2}
+          canceledAt={"2025-05-04T14:21:19.928435"}
+          booth={{
+            boothID: 1,
+            name: "찬주를 위한 취소 부스",
+            description: "아...언제끝나냐",
+            location: "우린 할 수 있어!",
+          }}
+        />
+      ),
+    });
+  };
+  return (
+    <TestToolContainer>
+      for 찬주...
+      <TestToolButton onClick={openCancelBottomSheet}>
+        취소 바텀시트 열기
+      </TestToolButton>
+    </TestToolContainer>
+  );
+};
+export default TestTool;
+
+const TestToolContainer = styled.section`
+  position: fixed;
+  top: 0;
+  left: 0;
+
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  opacity: 0.5;
+  background-color: aliceblue;
+  border: 1px solid black;
+
+  padding: 1rem;
+`;
+
+const TestToolButton = styled.button`
+  background-color: blue;
+  color: white;
+  padding: 0.5rem;
+  border-radius: 0.25rem;
+`;

--- a/apps/service/src/components/waitingCard/WaitingCard.tsx
+++ b/apps/service/src/components/waitingCard/WaitingCard.tsx
@@ -16,7 +16,9 @@ export interface WaitingCardProps
     | "waitingTeamsAhead"
     | "booth"
     | "confirmedAt"
-  > {}
+  > {
+  isOpacity?: boolean;
+}
 
 interface Config {
   type?: "black" | "white";
@@ -25,8 +27,14 @@ interface Config {
 }
 
 const WaitingCard = (props: WaitingCardProps) => {
-  const { waitingID, waitingStatus, waitingTeamsAhead, booth, confirmedAt } =
-    props;
+  const {
+    waitingID,
+    waitingStatus,
+    waitingTeamsAhead,
+    booth,
+    confirmedAt,
+    isOpacity = true,
+  } = props;
 
   const getConfig = (): Config => {
     switch (waitingStatus) {
@@ -89,7 +97,7 @@ const WaitingCard = (props: WaitingCardProps) => {
       as="section"
       direction="column"
       gap="0.75rem"
-      css={[S.getWaitingCardStyle(type, disabled)]}
+      css={[S.getWaitingCardStyle(type, isOpacity && disabled)]}
       onClick={disabled ? undefined : navigateWaitingDetail}
     >
       <BoothThumbnailCompact css={[S.getBoothThumbnailStyle()]} {...booth} />

--- a/apps/service/src/hooks/apis/waiting.tsx
+++ b/apps/service/src/hooks/apis/waiting.tsx
@@ -13,46 +13,59 @@ import { postSelectEntering } from "@apis/domains/waiting/postSelectEntering";
 import { useToast } from "@linenow/core/hooks";
 import { QUERY_KEY } from "./query";
 import { postCancelWaiting } from "@apis/domains/waiting/postCancelWaiting";
+import useAuth from "@hooks/useAuth";
 
 export const useGetWaitings = (type: "waiting" | "finished" = "waiting") => {
+  const { isLogin } = useAuth();
   return useQuery({
     queryKey: QUERY_KEY.WAITINGS(type),
     queryFn: () => getWaitings(type),
+    enabled: isLogin,
   });
 };
 
 export const useGetWaitingsCount = () => {
+  const { isLogin } = useAuth();
   return useQuery({
     queryKey: QUERY_KEY.WAITINGS_COUNT(),
     queryFn: () => getWaitingsCount,
+    enabled: isLogin,
   });
 };
 
 export const useGetWaiting = (waitingID: number) => {
+  const { isLogin } = useAuth();
   return useQuery({
     queryKey: QUERY_KEY.WAITING(waitingID),
     queryFn: () => getWaiting(waitingID),
+    enabled: isLogin,
   });
 };
 
 export const useGetWaitingBooth = (waitingID: number) => {
+  const { isLogin } = useAuth();
   return useQuery({
     queryKey: QUERY_KEY.WAITING_BOOTH(waitingID),
     queryFn: () => getWaitingBooth(waitingID),
+    enabled: isLogin,
   });
 };
 
 export const useGetCancelAllEntering = () => {
+  const { isLogin } = useAuth();
   return useQuery({
     queryKey: QUERY_KEY.ALL_ENTERINGS(),
     queryFn: () => getCancelAllEntering(),
+    enabled: isLogin,
   });
 };
 
 export const useGetCancelAllWaiting = () => {
+  const { isLogin } = useAuth();
   return useQuery({
     queryKey: QUERY_KEY.ALL_WAITINGS(),
     queryFn: () => getCancelAllWaiting(),
+    enabled: isLogin,
   });
 };
 

--- a/apps/service/src/hooks/useEntering.tsx
+++ b/apps/service/src/hooks/useEntering.tsx
@@ -1,13 +1,14 @@
 // hooks
-import { useMemo } from "react";
-import { useBottomSheet } from "@linenow/core/hooks";
+import { useEffect, useMemo, useState } from "react";
+
+import { useLocation } from "react-router-dom";
 import { useGetWaitings } from "./apis/waiting";
-import useEnteringContent from "@components/bottomSheet/entering/useEnteringContent";
 
-// components
+const useEntering = () => {
+  const location = useLocation();
+  const [isOpen, setIsOpen] = useState<boolean>(false);
 
-const useEnteringBottomSheet = () => {
-  const { data = [] } = useGetWaitings("waiting");
+  const { data = [], refetch } = useGetWaitings("waiting");
 
   const waitings = useMemo(
     () => data.filter((w) => w.waitingStatus === "waiting"),
@@ -18,21 +19,29 @@ const useEnteringBottomSheet = () => {
     [data]
   );
 
-  const sheetContent = useEnteringContent({
-    enterings,
-    waitings,
-  });
+  useEffect(() => {
+    refetch();
+    openBottomSheet();
+  }, [location.pathname, data]);
 
-  const { openBottomSheet, closeBottomSheet } = useBottomSheet();
-
-  const openEntering = () => {
-    if (enterings.length === 0) return;
-    openBottomSheet({ children: sheetContent });
+  const openBottomSheet = () => {
+    if (enterings.length !== 0) {
+      setIsOpen(true);
+    }
   };
 
-  const closeEntrace = () => closeBottomSheet();
+  const closeBottomSheet = () => {
+    setIsOpen(false);
+  };
 
-  return { openEntering, closeEntrace };
+  return {
+    openBottomSheet,
+    closeBottomSheet,
+    isOpen,
+    data,
+    waitings,
+    enterings,
+  };
 };
 
-export default useEnteringBottomSheet;
+export default useEntering;

--- a/apps/service/src/layouts/RootLayout.tsx
+++ b/apps/service/src/layouts/RootLayout.tsx
@@ -6,13 +6,14 @@ import {
   ModalProvider,
   ToastProvider,
 } from "@linenow/core/components";
-
-// hooks
+import EnteringBottomsheetProvider from "@components/bottomSheet/entering/EnteringBottohSheetProvider";
+import useAuth from "@hooks/useAuth";
 
 const RootLayout = () => {
-  // useCheckWaitingStatus();
+  const { isLogin } = useAuth();
   return (
     <>
+      {isLogin && <EnteringBottomsheetProvider />}
       <ToastProvider />
       <ModalProvider />
       <BottomSheetProvider />

--- a/apps/service/src/main.tsx
+++ b/apps/service/src/main.tsx
@@ -14,7 +14,7 @@ import ReactDOM from "react-dom/client";
 import App from "./App.tsx";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
+  // <React.StrictMode>
+  <App />
+  // </React.StrictMode>
 );

--- a/apps/service/src/main.tsx
+++ b/apps/service/src/main.tsx
@@ -14,7 +14,7 @@ import ReactDOM from "react-dom/client";
 import App from "./App.tsx";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
-  // <React.StrictMode>
-  <App />
-  // </React.StrictMode>
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
 );

--- a/apps/service/src/pages/main/_components/mainNavigation/MainNavigation.tsx
+++ b/apps/service/src/pages/main/_components/mainNavigation/MainNavigation.tsx
@@ -1,10 +1,8 @@
 import * as S from "./MainNavigation.styled";
-import MainNavigationWaitingList from "./MainNavigationWaitingList";
 
 import useMainViewType from "@pages/main/_hooks/useMainViewType";
 import useMainScroll from "@pages/main/_hooks/useMainScroll";
 import useAuth from "@hooks/useAuth";
-import WaitingCardLogin from "@components/waitingCard/WaitingCardLogin";
 import MainNavigationTitleGuest from "./title/MainNavigationTitleGuest";
 import MainNavigationTitleUser from "./title/MainNavigationTitleUser";
 import { Flex } from "@linenow/core/components";

--- a/apps/service/src/pages/myWaiting/_components/MyWaitingEmtpyView.tsx
+++ b/apps/service/src/pages/myWaiting/_components/MyWaitingEmtpyView.tsx
@@ -1,0 +1,18 @@
+import { Flex, Label } from "@linenow/core/components";
+
+interface MyWaitingEmptyViewProps {
+  type?: "waiting" | "finished";
+}
+
+const MyWaitingEmptyView = (props: MyWaitingEmptyViewProps) => {
+  const { type = "waiting" } = props;
+  return (
+    <Flex width="100%" padding="2rem" justifyContent="center">
+      <Label font="body2" color="grayLight">
+        {type === "waiting" ? "대기중인" : "대기 취소된"} 부스가 아직 없어요!
+      </Label>
+    </Flex>
+  );
+};
+
+export default MyWaitingEmptyView;

--- a/apps/service/src/pages/myWaiting/_components/MyWaitingList.tsx
+++ b/apps/service/src/pages/myWaiting/_components/MyWaitingList.tsx
@@ -3,6 +3,7 @@ import { Flex } from "@linenow/core/components";
 import WaitingCard from "@components/waitingCard/WaitingCard";
 import Notice from "@components/notice/Notice";
 import { useGetWaitings } from "@hooks/apis/waiting";
+import MyWaitingEmptyView from "./MyWaitingEmtpyView";
 
 interface MyWaitingListProps {
   type: "waiting" | "finished";
@@ -22,7 +23,7 @@ const MyWaitingList = (props: MyWaitingListProps) => {
       )}
 
       {/* 대기 목록 */}
-      {waitings.length === 0 && <div>EMPTY VIEW</div>}
+      {waitings.length === 0 && <MyWaitingEmptyView type={type} />}
       {waitings.map((waiting, index) => (
         <WaitingCard key={index} {...waiting} />
       ))}

--- a/apps/service/src/pages/setting/SettingPage.tsx
+++ b/apps/service/src/pages/setting/SettingPage.tsx
@@ -28,18 +28,18 @@ const SettingPage = () => {
   };
 
   // 개발자 정보 클릭
-  const handleDeveloperInfoClick = () => {
-    window.open(
-      "https://thorn-freesia-96f.notion.site/09b2230a514848ec9041518f467f86e4?pvs=4",
-      "_blank"
-    );
-  };
+  // const handleDeveloperInfoClick = () => {
+  //   window.open(
+  //     "https://thorn-freesia-96f.notion.site/09b2230a514848ec9041518f467f86e4?pvs=4",
+  //     "_blank"
+  //   );
+  // };
 
   const settingItemProps = [
     { title: "로그아웃", onClick: handleLogoutClick },
     { title: "이용약관", onClick: handleTermsOfServiceClick },
     { title: "1:1 문의", onClick: handleInquiryClick },
-    { title: "개발자 정보", onClick: handleDeveloperInfoClick },
+    // { title: "개발자 정보", onClick: handleDeveloperInfoClick },
   ];
 
   return (

--- a/packages/core/src/components/fixedContainer/FixedContainer.tsx
+++ b/packages/core/src/components/fixedContainer/FixedContainer.tsx
@@ -1,6 +1,6 @@
 import * as S from "./FixedContainer.styled";
 
-export interface FixedContainerProps extends React.PropsWithChildren {
+export interface FixedContainerProps extends React.ComponentProps<"section"> {
   zIndex?: number;
   justifyContent?: "start" | "center" | "end";
   closeContainer?: () => void;
@@ -12,11 +12,15 @@ const FixedContainer = (props: FixedContainerProps) => {
     justifyContent = "center",
     children,
     closeContainer,
+    ...attributes
   } = props;
 
   return (
     <>
-      <section css={[S.getFixedContainerStyle(zIndex, justifyContent)]}>
+      <section
+        css={[S.getFixedContainerStyle(zIndex, justifyContent)]}
+        {...attributes}
+      >
         <div onClick={closeContainer} css={[S.getFixedBackgroundStyle]} />
         {children}
       </section>

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -24,5 +24,7 @@ export { default as Modal, type ModalProps } from "./modal/Modal";
 export { default as ModalProvider } from "./modal/ModalProvider";
 export { default as Toast } from "./toast/Toast";
 export { default as ToastProvider } from "./toast/ToastProvider";
+
+export { default as FixedContainer } from "./fixedContainer/FixedContainer";
 export { default as BottomSheet } from "./bottomSheet/BottomSheet";
 export { default as BottomSheetProvider } from "./bottomSheet/BottomSheetProvider";


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
- 입장 취소 바텀시트
- 입장 가능 바텀시트, 페이지 이동할때마다 뜨게... (사용방법 모르겠으면 저한테 문의주세욥)
- 대기 앰티뷰
- 설정 페이지 수정
- 약간의 성능 개선 (필요없는 부분에서 필요없는 API 호출되는걸 막았습니다.)

## 🚨 참고 사항

- 입장 취소 바텀시트 완료했습니다! @ohchanju3  이어서 작업해주시면돼요.
- 사용방법은 Test Tool을 참고해주시면됩니다.

| 구현 내용 |           Desktop           |    
| :-------: | :-------------------------: |
|    GIF    | <img src = "https://github.com/user-attachments/assets/1a7c4f09-8c27-41fa-9c77-b8a11b3b55f2" width ="250"> | 


## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 📟 관련 이슈

- Resolved: #56 
