### PR TITLE
[Feat]#61-사용자 소켓 구현

### DIFF
--- a/apps/service/src/hooks/socket/useSocket.ts
+++ b/apps/service/src/hooks/socket/useSocket.ts
@@ -1,0 +1,55 @@
+import { useAtomValue } from "jotai";
+import { authAtom } from "@atoms/auth";
+import { useEffect, useRef } from "react";
+
+const useWebSocket = (onMessageCallback: (message: any) => void) => {
+  const auth = useAtomValue(authAtom);
+  const socketRef = useRef<WebSocket | null>(null);
+
+  useEffect(() => {
+    const token = localStorage.getItem("accessToken");
+    const baseSocketUrl = import.meta.env.VITE_BASE_SOCKET_URL;
+
+    if (!token) {
+      console.log("토큰이 없습니다!");
+      return;
+    }
+
+    const socket = new WebSocket(
+      `${baseSocketUrl}/ws/waiting/user?token=${token}`
+    );
+
+    socket.onopen = () => {
+      console.log("WebSocket 연결됨");
+    };
+
+    socket.onmessage = (event) => {
+      console.log("받은 메시지:", event.data);
+      try {
+        const data = JSON.parse(event.data);
+        console.log("파싱된 데이터:", data);
+        onMessageCallback?.(data);
+      } catch (error) {
+        console.error("JSON 파싱 실패:", error);
+      }
+    };
+
+    socket.onerror = (error) => {
+      console.error("WebSocket 에러:", error);
+    };
+
+    socket.onclose = () => {
+      console.log("WebSocket 연결 종료");
+    };
+
+    // cleanup
+    return () => {
+      socket.close();
+      console.log("웹소켓 종료");
+    };
+  }, [auth, onMessageCallback]);
+
+  return socketRef;
+};
+
+export default useWebSocket;

--- a/apps/service/src/hooks/socket/useSocketEnterRoute.ts
+++ b/apps/service/src/hooks/socket/useSocketEnterRoute.ts
@@ -1,0 +1,12 @@
+import useEnteringBottomSheet from "@hooks/useEntering";
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export const useSocketEnterRoute = () => {
+  const location = useLocation();
+  const { openEntering } = useEnteringBottomSheet();
+
+  useEffect(() => {
+    openEntering();
+  }, [location.pathname]);
+};

--- a/apps/service/src/hooks/socket/useSocketEnterings.ts
+++ b/apps/service/src/hooks/socket/useSocketEnterings.ts
@@ -4,12 +4,18 @@ import useWebSocket from "./useSocket";
 import { mapToWaiting } from "@utils/mapToWaiting";
 
 const useSocketEnterings = () => {
+  //TODO: 대기 취소 바텀시트 머지 후 주석 해제
+  // const { openEnteringWithFullData, openCancelBottomSheet } =
   const { openEnteringWithFullData } = useEnteringBottomSheet();
 
   const handleSocketMessage = useCallback(
     (data: any) => {
       const enteringWaitings = data?.data?.entering_waitings;
+      //TODO: 대기 취소 바텀시트 머지 후 주석 해제
+      // const canceled =
+      //   data?.data?.waiting_status === "canceled" ? data.data : null;
 
+      //입장 알림
       if (Array.isArray(enteringWaitings) && enteringWaitings.length > 0) {
         const validEnterings = enteringWaitings
           .filter((waiting) => waiting.waiting_status === "entering")
@@ -19,7 +25,17 @@ const useSocketEnterings = () => {
           openEnteringWithFullData(validEnterings);
         }
       }
+
+      //TODO: 대기 취소 바텀시트 머지 후 주석 해제
+      //   if (canceled) {
+      //     const mapped = mapToWaiting(canceled);
+      //     console.log("❌ 대기 취소 소켓 메시지:", mapped);
+      //     openCancelBottomSheet(mapped);
+      //   }
     },
+
+    //TODO: 대기 취소 바텀시트 머지 후 주석 해제
+    // [openEnteringWithFullData, openCancelBottomSheet]
     [openEnteringWithFullData]
   );
 

--- a/apps/service/src/hooks/socket/useSocketEnterings.ts
+++ b/apps/service/src/hooks/socket/useSocketEnterings.ts
@@ -1,0 +1,29 @@
+import { useCallback } from "react";
+import useEnteringBottomSheet from "../useEntering";
+import useWebSocket from "./useSocket";
+import { mapToWaiting } from "@utils/mapToWaiting";
+
+const useSocketEnterings = () => {
+  const { openEnteringWithFullData } = useEnteringBottomSheet();
+
+  const handleSocketMessage = useCallback(
+    (data: any) => {
+      const enteringWaitings = data?.data?.entering_waitings;
+
+      if (Array.isArray(enteringWaitings) && enteringWaitings.length > 0) {
+        const validEnterings = enteringWaitings
+          .filter((waiting) => waiting.waiting_status === "entering")
+          .map(mapToWaiting);
+
+        if (validEnterings.length > 0) {
+          openEnteringWithFullData(validEnterings);
+        }
+      }
+    },
+    [openEnteringWithFullData]
+  );
+
+  useWebSocket(handleSocketMessage);
+};
+
+export default useSocketEnterings;

--- a/apps/service/src/hooks/useEntering.tsx
+++ b/apps/service/src/hooks/useEntering.tsx
@@ -3,6 +3,8 @@ import { useBottomSheet } from "@linenow/core/hooks";
 import { useGetWaitings } from "./apis/waiting";
 import useEnteringContent from "@components/bottomSheet/entering/useEnteringContent";
 import { Waiting } from "@interfaces/waiting";
+//TODO: 대기 취소 바텀시트 머지 후 주석 해제
+// import CancelBottomSheetContent from "@components/bottomSheet/cancel/CancelBottomSheet";
 
 const useEnteringBottomSheet = () => {
   const { data = [] } = useGetWaitings("waiting");
@@ -48,9 +50,22 @@ const useEnteringBottomSheet = () => {
     }
   }, [data]);
 
+  //TODO: 대기 취소 바텀시트 머지 후 주석 해제
+  // const openCancelBottomSheet = (waiting: Waiting) => {
+  //   openBottomSheet({
+  //     children: <CancelBottomSheetContent {...waiting} />,
+  //   });
+  // };
+
   const closeEntrace = () => closeBottomSheet();
 
-  return { openEntering, closeEntrace, openEnteringWithFullData };
+  return {
+    openEntering,
+    closeEntrace,
+    openEnteringWithFullData,
+    //TODO: 대기 취소 바텀시트 머지 후 주석 해제
+    // openCancelBottomSheet,
+  };
 };
 
 export default useEnteringBottomSheet;

--- a/apps/service/src/layouts/RootLayout.tsx
+++ b/apps/service/src/layouts/RootLayout.tsx
@@ -6,11 +6,14 @@ import {
   ModalProvider,
   ToastProvider,
 } from "@linenow/core/components";
+import { useSocketEnterRoute } from "@hooks/socket/useSocketEnterRoute";
+import useSocketEnterings from "@hooks/socket/useSocketEnterings";
 
 // hooks
 
 const RootLayout = () => {
-  // useCheckWaitingStatus();
+  useSocketEnterRoute();
+  useSocketEnterings();
   return (
     <>
       <ToastProvider />

--- a/apps/service/src/utils/mapToWaiting.ts
+++ b/apps/service/src/utils/mapToWaiting.ts
@@ -1,0 +1,20 @@
+//소켓에서 받아온 데이터를 Waiting 타입에 맞게 매핑하는 유틸
+
+import { Waiting } from "@interfaces/waiting";
+
+export const mapToWaiting = (raw: any): Waiting => ({
+  waitingID: raw.waiting_id,
+  waitingNum: raw.waiting_num,
+  personCount: raw.person_num,
+  createdAt: raw.created_at,
+  confirmedAt: raw.confirmed_at,
+  canceledAt: raw.canceled_at,
+  waitingStatus: raw.waiting_status,
+  booth: {
+    boothID: raw.booth_info?.booth_id,
+    name: raw.booth_info?.booth_name,
+    location: raw.booth_info?.booth_location,
+    thumbnail: raw.booth_info?.booth_thumbnail,
+  },
+  waitingTeamsAhead: raw.waitingsTeamsAhead ?? [],
+});


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용

<!-- 작업한 내용을 적어주세요. -->
사용자 소켓을 연결했습니다.

- 관리자가 대기 호출시 입장 바텀시트 소켓 연결(머물러있던 페이지에서는 소켓에서 받아온 데이터를 변환해 바텀시트 데이터에 넣어주었고, 경로를 이동할때마다 바텀시트가 뜨도록 했습니다.)
- 관리자가 대기 취소시 관련 바텀시트 소켓 연결

## 🚨 참고 사항

<!-- 참고할 사항이 있다면 적어주세요. -->
- 취소 바텀시트는 아직 머지가 안된 상태여서 기능 구현 후 주석 처리해놓았습니다! 서현언니 pr 머지된 후에 주석 해제할 예정입니다.


## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. -->

`useSocketEnterRoute`

- 경로가 바뀌어도 소켓이 계속 연결되어 바텀시트가 열리는 훅입니다.

```typescript
import useEnteringBottomSheet from "@hooks/useEntering";
import { useEffect } from "react";
import { useLocation } from "react-router-dom";

export const useSocketEnterRoute = () => {
  const location = useLocation();
  const { openEntering } = useEnteringBottomSheet();

  useEffect(() => {
    openEntering();
  }, [location.pathname]);
};

```

## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 📟 관련 이슈

- #61
