### PR TITLE
[Fix] #69 - 지도 대규모 수정

### DIFF
--- a/apps/service/src/atoms/location.ts
+++ b/apps/service/src/atoms/location.ts
@@ -1,9 +1,14 @@
 import { atom } from "jotai";
 
+export const DEFAULT_LOCATION = {
+  lat: 37.5584809,
+  lng: 127.0004067,
+};
+
 export const latLngAtom = atom<{
   lat: number;
-  lon: number;
+  lng: number;
 }>({
-  lat: 37.5584809,
-  lon: 127.0004067,
+  lat: DEFAULT_LOCATION.lat,
+  lng: DEFAULT_LOCATION.lng,
 });

--- a/apps/service/src/components/boothLocationMap/BoothLocationMap.tsx
+++ b/apps/service/src/components/boothLocationMap/BoothLocationMap.tsx
@@ -25,7 +25,7 @@ export const BoothLocationMap = ({ booth }: BoothLocationContentProps) => {
         <S.BoothLocationMapClickableBar
           onClick={() => {
             setViewType("map");
-            navigate("/");
+            navigate("/", { state: booth.boothID });
           }}
         >
           클릭해서 지도 보기

--- a/apps/service/src/components/boothLocationMap/BoothLocationMap.tsx
+++ b/apps/service/src/components/boothLocationMap/BoothLocationMap.tsx
@@ -6,6 +6,8 @@ import { useNavigate } from "react-router-dom";
 import useMainViewType from "@pages/main/_hooks/useMainViewType";
 import { Icon } from "@linenow/core/components";
 import { useToast } from "@linenow/core/hooks";
+import { useSetAtom } from "jotai";
+import { latLngAtom } from "@atoms/location";
 
 interface BoothLocationContentProps {
   booth: Booth;
@@ -14,6 +16,7 @@ interface BoothLocationContentProps {
 export const BoothLocationMap = ({ booth }: BoothLocationContentProps) => {
   const mapRef = useRef<null | HTMLDivElement>(null);
   const navigate = useNavigate();
+  const setLatLng = useSetAtom(latLngAtom);
   const { setViewType } = useMainViewType();
 
   const { presentToast } = useToast();
@@ -26,6 +29,10 @@ export const BoothLocationMap = ({ booth }: BoothLocationContentProps) => {
           onClick={() => {
             setViewType("map");
             navigate("/", { state: booth.boothID });
+            setLatLng({
+              lat: Number(booth.latitude),
+              lng: Number(booth.longitude),
+            });
           }}
         >
           클릭해서 지도 보기

--- a/apps/service/src/components/refetchButton/RefetchButton.tsx
+++ b/apps/service/src/components/refetchButton/RefetchButton.tsx
@@ -17,6 +17,7 @@ const useQueriesAreFetching = (queries: QueryKey[]): boolean => {
 const RefetchButton = (props: RefetchButtonProps) => {
   const { queries, ...buttonProps } = props;
 
+  console.log(queries);
   const queryClient = useQueryClient();
   const isFetching = useQueriesAreFetching(queries);
 

--- a/apps/service/src/hooks/useSmallNaverMap.tsx
+++ b/apps/service/src/hooks/useSmallNaverMap.tsx
@@ -43,7 +43,7 @@ export const useSmallNaverMap = (
           const map = new naver.maps.Map(mapRef.current, {
             center: now,
             zoom: 18,
-            zoomControl: true,
+            // zoomControl: true,
             zoomControlOptions: {
               style: window.naver.maps.ZoomControlStyle.SMALL,
               position: window.naver.maps.Position.TOP_RIGHT,

--- a/apps/service/src/pages/boothDetail/BoothDetailPage.tsx
+++ b/apps/service/src/pages/boothDetail/BoothDetailPage.tsx
@@ -130,7 +130,7 @@ const BoothDetailPage = () => {
           </Flex>
           <Separator height={8} />
 
-          <BoothLocationMap booth={booth} />
+          {!isModalOpen && <BoothLocationMap booth={booth} />}
 
           <Separator height={8} />
 

--- a/apps/service/src/pages/main/MainPage.styled.ts
+++ b/apps/service/src/pages/main/MainPage.styled.ts
@@ -59,17 +59,13 @@ const positionStyles: Record<Position, ReturnType<typeof css>> = {
   `,
 };
 
-export const getFloatingButtonStyle = (
-  buttonType: FloatingButtonType,
-  viewType: MainViewType = "list"
-) => {
+export const getFloatingButtonStyle = (buttonType: FloatingButtonType) => {
   const config = floatingButtonStyleConfigs[buttonType];
-  const extraBottom = viewType === "map" ? "6rem" : "0rem";
 
   return css`
     position: absolute;
     ${positionStyles[config.position]}
-    bottom: calc(${config.bottom} + ${extraBottom});
+    bottom: calc(${config.bottom} );
 
     box-shadow: 0px 1px 5px 2px rgba(26, 30, 39, 0.1);
   `;

--- a/apps/service/src/pages/main/MainPage.tsx
+++ b/apps/service/src/pages/main/MainPage.tsx
@@ -16,20 +16,19 @@ import { Switch } from "@linenow/core/components";
 import * as S from "./MainPage.styled";
 import MainNavigation from "./_components/mainNavigation/MainNavigation";
 import MainBoothListHeader from "./_components/boothList/MainBoothListHeader";
-
-import {
-  MyLocationButton,
-  FestivalLocation,
-} from "@pages/main/_components/map/MainLocationButton";
+import { useAtomValue } from "jotai";
+import { isSelectedBoothAtom } from "./_atom/selectedBooth";
 
 const MainPage = () => {
-  const { isLogin } = useAuth();
-
   const { viewType, mainViewTypeSwitchProps } = useMainViewType();
   const { getBoothListHeaderChildren, BoothList } = useMainBoothList();
 
+  const { isLogin } = useAuth();
+
   // refetch queries
   const { queries } = isLogin ? useGetMainDataUser() : useGetMainDataGuest();
+  const selectedBoothStatus = useAtomValue(isSelectedBoothAtom);
+  console.log(selectedBoothStatus);
 
   return (
     <>
@@ -40,33 +39,20 @@ const MainPage = () => {
       </MainNavigation>
 
       <BoothList />
-      {/* <SelectedBoothCard /> */}
 
-      {/* floating button */}
-      <div css={S.getFloatingButtonWrapperStyle(viewType)}>
-        {/* 새로고침 버튼 */}
-        <RefetchButton
-          css={S.getFloatingButtonStyle("refetch", viewType)}
-          queries={queries}
-        />
+      {viewType === "list" && (
+        <div css={S.getFloatingButtonWrapperStyle(viewType)}>
+          <RefetchButton
+            css={S.getFloatingButtonStyle("refetch")}
+            queries={queries}
+          />
 
-        {viewType === "map" && (
-          <>
-            <MyLocationButton
-              css={S.getFloatingButtonStyle("my_location", viewType)}
-            />
-            <FestivalLocation
-              css={S.getFloatingButtonStyle("festival_location", viewType)}
-            />
-          </>
-        )}
-
-        {/* list, map 토글 버튼 */}
-        <Switch
-          css={S.getFloatingButtonStyle("switch", viewType)}
-          {...mainViewTypeSwitchProps}
-        />
-      </div>
+          <Switch
+            css={S.getFloatingButtonStyle("switch")}
+            {...mainViewTypeSwitchProps}
+          />
+        </div>
+      )}
     </>
   );
 };

--- a/apps/service/src/pages/main/_atom/selectedBooth.tsx
+++ b/apps/service/src/pages/main/_atom/selectedBooth.tsx
@@ -1,3 +1,3 @@
 import { atom } from "jotai";
 
-export const selectedBoothAtom = atom<boolean>(false);
+export const isSelectedBoothAtom = atom<boolean>(false);

--- a/apps/service/src/pages/main/_components/boothList/MainBoothList.styled.ts
+++ b/apps/service/src/pages/main/_components/boothList/MainBoothList.styled.ts
@@ -24,7 +24,6 @@ export const getHeaderWrapperStyle = (type: MainViewType) => {
     return css`
       display: flex;
       flex-direction: column;
-
       gap: 1rem;
 
       border-radius: 0.625rem 0.625rem 0rem 0rem;

--- a/apps/service/src/pages/main/_components/mainNavigation/MainNavigation.styled.ts
+++ b/apps/service/src/pages/main/_components/mainNavigation/MainNavigation.styled.ts
@@ -28,7 +28,6 @@ export const getWrapper = (type: MainViewType, isFold: boolean) => {
       `;
 
     return css`
-      z-index: 1;
       position: fixed;
       overflow-y: hidden;
       max-width: ${theme.maxWidth};

--- a/apps/service/src/pages/main/_components/map/MainLocationButton.tsx
+++ b/apps/service/src/pages/main/_components/map/MainLocationButton.tsx
@@ -1,7 +1,7 @@
 import { useSetAtom } from "jotai";
 import * as S from "./MainLocationButton.styled";
 import { Button, Icon } from "@linenow/core/components";
-import { latLngAtom } from "@atoms/location";
+import { DEFAULT_LOCATION, latLngAtom } from "@atoms/location";
 
 export const MyLocationButton = ({
   ...buttonProps
@@ -17,8 +17,8 @@ export const MyLocationButton = ({
     navigator.geolocation.getCurrentPosition(
       (position) => {
         const lat = position.coords.latitude;
-        const lon = position.coords.longitude;
-        setLatLng({ lat, lon });
+        const lng = position.coords.longitude;
+        setLatLng({ lat, lng });
       },
       (error) => {
         console.error("위치 정보를 가져오는 데 실패했습니다:", error.message);
@@ -51,8 +51,8 @@ export const FestivalLocation = ({
 
   const handleMoveToFestivalLocation = () => {
     setLatLng({
-      lat: 37.55822161540249,
-      lon: 127.00019240184307,
+      lat: DEFAULT_LOCATION.lat,
+      lng: DEFAULT_LOCATION.lng,
     });
   };
 

--- a/apps/service/src/pages/main/_components/map/MainMap.styled.ts
+++ b/apps/service/src/pages/main/_components/map/MainMap.styled.ts
@@ -1,16 +1,21 @@
-import { css } from "@emotion/react";
+import { css, Theme } from "@emotion/react";
+import { MainViewType } from "@pages/main/types";
+import { changeFoldStateAnimation } from "@styles/animation";
 
 export const getWrapper = () => css`
   z-index: 1;
   width: 100%;
   overflow: hidden;
-  height: calc(100vh - 16rem);
 
-  /* animation: expandHeight 0.8s ease forwards; */
   position: absolute;
   top: calc(13rem);
+  z-index: 1;
 
-  /* @keyframes expandHeight {
+  height: calc(100vh - 16rem);
+
+  /* animation: expandHeight 0.8s ease forwards;
+
+  @keyframes expandHeight {
     0% {
       height: 13rem;
     }
@@ -23,3 +28,76 @@ export const getWrapper = () => css`
 export const getButtonStyle = () => css`
   padding: 1rem;
 `;
+
+export const getFloatingButtonWrapperStyle =
+  (viewType: MainViewType) => (theme: Theme) => {
+    const getBottom = viewType === "list" ? "1rem" : "4rem";
+    return css`
+      /* main page의 header 보다 위에 */
+      z-index: 2;
+      position: fixed;
+      bottom: ${getBottom};
+      transform: translateX(-50%);
+      left: 50%;
+
+      width: 100%;
+      max-width: ${theme.maxWidth};
+
+      ${changeFoldStateAnimation};
+    `;
+  };
+
+type Position = "left" | "center" | "right";
+
+type FloatingButtonType =
+  | "refetch"
+  | "switch"
+  | "my_location"
+  | "festival_location";
+
+interface FloatingButtonStyleConfig {
+  position: Position;
+  bottom: string;
+}
+
+const floatingButtonStyleConfigs: Record<
+  FloatingButtonType,
+  FloatingButtonStyleConfig
+> = {
+  refetch: { position: "left", bottom: "0rem" },
+  switch: { position: "center", bottom: "0rem" },
+  my_location: { position: "right", bottom: "4rem" },
+  festival_location: { position: "right", bottom: "0rem" },
+};
+
+const positionStyles: Record<Position, ReturnType<typeof css>> = {
+  left: css`
+    left: 1rem;
+  `,
+  center: css`
+    left: 50%;
+    transform: translateX(-50%);
+    &:hover {
+      transform: translateX(-50%) scale(0.95);
+    }
+  `,
+  right: css`
+    right: 1rem;
+  `,
+};
+
+export const getFloatingButtonStyle = (
+  buttonType: FloatingButtonType,
+  viewType: MainViewType = "list"
+) => {
+  const config = floatingButtonStyleConfigs[buttonType];
+  const extraBottom = viewType === "map" ? "6rem" : "4rem";
+
+  return css`
+    position: absolute;
+    ${positionStyles[config.position]}
+    bottom: calc(${config.bottom} + ${extraBottom});
+
+    box-shadow: 0px 1px 5px 2px rgba(26, 30, 39, 0.1);
+  `;
+};

--- a/apps/service/src/pages/main/_components/map/MainMap.tsx
+++ b/apps/service/src/pages/main/_components/map/MainMap.tsx
@@ -3,14 +3,19 @@ import * as S from "./MainMap.styled";
 import { BoothPinProps, useNaverMap } from "@pages/main/_hooks/useNaverMap";
 import { memo, useRef, useState } from "react";
 import { SelectedBoothCard } from "./MainSelectedBoothCard";
+import { useLocation } from "react-router-dom";
 
 interface MainMapProps {
   booths: BoothPinProps[];
 }
 const MainMap = memo((props: MainMapProps) => {
   const { booths } = props;
+  const location = useLocation();
+
   const selectedBoothIdRef = useRef<number | null>(null);
-  const [selectedBoothId, setSelectedBoothId] = useState<number | null>(null);
+  const [selectedBoothId, setSelectedBoothId] = useState<number | null>(
+    location.state || null
+  );
 
   const safeSetSelectedBoothId = (id: number | null) => {
     selectedBoothIdRef.current = id;

--- a/apps/service/src/pages/main/_components/map/MainSelectedBoothCard.tsx
+++ b/apps/service/src/pages/main/_components/map/MainSelectedBoothCard.tsx
@@ -1,3 +1,4 @@
+import * as S from "./MainMap.styled";
 import { css, Theme } from "@emotion/react";
 import { Link } from "react-router-dom";
 
@@ -5,6 +6,10 @@ import BoothThumbnailBadge, {
   BoothThumbnailBadgeProps,
 } from "@components/booth/BoothThumbnailBadge";
 import useBoothListData from "@pages/main/_hooks/useBoothListData";
+import { Switch } from "@linenow/core/components";
+import useMainViewType from "@pages/main/_hooks/useMainViewType";
+import { FestivalLocation, MyLocationButton } from "./MainLocationButton";
+import RefetchButton from "@components/refetchButton/RefetchButton";
 
 const getBoothListItemStyle = () => (theme: Theme) =>
   css`
@@ -37,26 +42,71 @@ type Props = {
 
 export const SelectedBoothCard = ({ selectedBoothId }: Props) => {
   const { currentBooths } = useBoothListData();
+  const { mainViewTypeSwitchProps } = useMainViewType();
 
-  if (!selectedBoothId || currentBooths.length === 0) return null;
+  if (selectedBoothId === null || currentBooths.length === 0)
+    return (
+      <div css={S.getFloatingButtonWrapperStyle("list")}>
+        <Switch
+          css={S.getFloatingButtonStyle("switch", "list")}
+          {...mainViewTypeSwitchProps}
+        />
+        <MyLocationButton
+          css={S.getFloatingButtonStyle("my_location", "list")}
+        />
+        <FestivalLocation
+          css={S.getFloatingButtonStyle("festival_location", "list")}
+        />
+
+        <RefetchButton
+          queries={[
+            ["booths"],
+            ["waitings-waiting"],
+            ["booths-waiting"],
+            ["booths-location"],
+          ]}
+          css={S.getFloatingButtonStyle("refetch", "list")}
+        />
+      </div>
+    );
 
   const booth = currentBooths.find((b) => b.boothID === selectedBoothId);
 
   if (!booth) return null;
 
-  const badgeProps: BoothThumbnailBadgeProps = {
-    ...booth,
-  };
-
+  const badgeProps: BoothThumbnailBadgeProps = { ...booth };
   return (
-    <Link
-      to={`/booth/${booth.boothID}`}
-      css={(theme) => css`
-        ${getSelectedBoothCardStyle()(theme)}
-        ${getBoothListItemStyle()(theme)}
-      `}
-    >
-      <BoothThumbnailBadge {...badgeProps} />
-    </Link>
+    <>
+      <div css={S.getFloatingButtonWrapperStyle("map")}>
+        <Switch
+          css={S.getFloatingButtonStyle("switch", "map")}
+          {...mainViewTypeSwitchProps}
+        />
+        <MyLocationButton
+          css={S.getFloatingButtonStyle("my_location", "map")}
+        />
+        <FestivalLocation
+          css={S.getFloatingButtonStyle("festival_location", "map")}
+        />
+        <RefetchButton
+          queries={[
+            ["booths"],
+            ["waitings-waiting"],
+            ["booths-waiting"],
+            ["booths-location"],
+          ]}
+          css={S.getFloatingButtonStyle("refetch", "map")}
+        />
+      </div>
+      <Link
+        to={`/booth/${booth.boothID}`}
+        css={(theme) => css`
+          ${getSelectedBoothCardStyle()(theme)}
+          ${getBoothListItemStyle()(theme)}
+        `}
+      >
+        <BoothThumbnailBadge {...badgeProps} />
+      </Link>
+    </>
   );
 };

--- a/apps/service/src/pages/main/_hooks/useBoothList.tsx
+++ b/apps/service/src/pages/main/_hooks/useBoothList.tsx
@@ -10,7 +10,6 @@ const useMainBoothList = () => {
   const { viewType } = useMainViewType();
   const { currentBooths } = useBoothListData();
 
-  // 고민 좀 해보기...
   const getBoothListHeaderChildren = () =>
     viewType === "list" && (
       <Flex justifyContent="space-between">

--- a/apps/service/src/pages/main/_hooks/useMainViewType.tsx
+++ b/apps/service/src/pages/main/_hooks/useMainViewType.tsx
@@ -1,9 +1,8 @@
-import { useAtom, useSetAtom } from "jotai";
+import { useAtom } from "jotai";
 import { mainViewTypeAtom } from "../_atom/mainViewType";
 import { MainViewType } from "../types";
 import { IconKey } from "@linenow/core/types";
 import { Switch } from "@linenow/core/components";
-import { selectedBoothAtom } from "../_atom/selectedBooth";
 
 interface MainViewTypeConfig {
   toggleType: MainViewType;
@@ -28,14 +27,13 @@ const mainViewTypeConfigs: MainViewTypeConfigs = {
 
 const useMainViewType = () => {
   const [mainViewType, setMainViewType] = useAtom(mainViewTypeAtom);
-  const setSelectedBooth = useSetAtom(selectedBoothAtom);
   const config = mainViewTypeConfigs[mainViewType];
 
   // view type을 전환하는 버튼
   const mainViewTypeSwitchProps: React.ComponentProps<typeof Switch> = {
     icon: config.switchIcon,
     onClick: () => {
-      setMainViewType(config.toggleType), setSelectedBooth(false);
+      setMainViewType(config.toggleType);
     },
     children: config.switchLabel,
   };

--- a/apps/service/src/pages/main/_hooks/useNaverMap.tsx
+++ b/apps/service/src/pages/main/_hooks/useNaverMap.tsx
@@ -3,7 +3,7 @@ import { createRoot } from "react-dom/client";
 
 import { loadScript } from "@utils/loadScript";
 import { useAtomValue } from "jotai";
-import { latLngAtom } from "@atoms/location";
+import { DEFAULT_LOCATION, latLngAtom } from "@atoms/location";
 import FocusPin from "../_components/map/pin/FocusPin";
 import DefautlPin from "../_components/map/pin/DefaultPin";
 
@@ -53,7 +53,10 @@ export const useNaverMap = (
         if (!window.naver) return;
         const { naver } = window;
         if (mapRef.current && window) {
-          const now = new naver.maps.LatLng(37.5584809, 127.0004067);
+          const now = new naver.maps.LatLng(
+            DEFAULT_LOCATION.lat,
+            DEFAULT_LOCATION.lng
+          );
           const map = new naver.maps.Map(mapRef.current, {
             center: now,
             zoom: 16,
@@ -65,8 +68,9 @@ export const useNaverMap = (
           });
 
           mapInstanceRef.current = map;
-          window.naver.maps.Event.addListener(map, "click", () => {
+          window.naver.maps.Event.addListener(map, "click", (e: any) => {
             setSelectedBoothId(null);
+            map.panTo(e?.latlng);
           });
 
           setIsMapReady(true);
@@ -121,9 +125,9 @@ export const useNaverMap = (
     if (!mapInstanceRef.current) return;
     const map = mapInstanceRef.current;
     const center = map.getCenter();
-    if (center.y === latLng.lat && center.x === latLng.lon) return;
+    if (center.y === latLng.lat && center.x === latLng.lng) return;
 
-    map.panTo(new naver.maps.LatLng(latLng.lat, latLng.lon));
+    map.panTo(new naver.maps.LatLng(latLng.lat, latLng.lng));
   }, [latLng]);
 
   return { mapRef };

--- a/apps/service/src/pages/main/_hooks/useNaverMap.tsx
+++ b/apps/service/src/pages/main/_hooks/useNaverMap.tsx
@@ -3,7 +3,7 @@ import { createRoot } from "react-dom/client";
 
 import { loadScript } from "@utils/loadScript";
 import { useAtomValue } from "jotai";
-import { DEFAULT_LOCATION, latLngAtom } from "@atoms/location";
+import { latLngAtom } from "@atoms/location";
 import FocusPin from "../_components/map/pin/FocusPin";
 import DefautlPin from "../_components/map/pin/DefaultPin";
 
@@ -53,13 +53,10 @@ export const useNaverMap = (
         if (!window.naver) return;
         const { naver } = window;
         if (mapRef.current && window) {
-          const now = new naver.maps.LatLng(
-            DEFAULT_LOCATION.lat,
-            DEFAULT_LOCATION.lng
-          );
+          const now = new naver.maps.LatLng(latLng.lat, latLng.lng);
           const map = new naver.maps.Map(mapRef.current, {
             center: now,
-            zoom: 16,
+            zoom: 17,
             zoomControl: true,
             zoomControlOptions: {
               style: window.naver.maps.ZoomControlStyle.SMALL,

--- a/apps/service/src/pages/waitingDetail/WaitingDetailPage.tsx
+++ b/apps/service/src/pages/waitingDetail/WaitingDetailPage.tsx
@@ -9,10 +9,11 @@ import Spinner from "@components/spinner/Spinner";
 import { useGetWaiting, useGetWaitingBooth } from "@hooks/apis/waiting";
 import { Button, Toast } from "@linenow/core/components";
 import { useModal } from "@linenow/core/hooks";
-import WaitingDetailMap from "./_components/WaitingDetailMap";
 
 import useToastFromLocation from "@hooks/useToastFromLocation";
 import { useModalCancelWaiting } from "@components/modal/waiting";
+import { useGetBooth } from "@hooks/apis/booth";
+import { BoothLocationMap } from "@components/boothLocationMap/BoothLocationMap";
 // import useAnimation from "./hooks/useAnimation";  // 주석 처리
 
 const WaitingDetailPage = () => {
@@ -23,6 +24,9 @@ const WaitingDetailPage = () => {
 
   const { data: waitingDetail, isLoading } = useGetWaiting(waitingID);
   const { data: waitingBooth } = useGetWaitingBooth(waitingID);
+
+  const { data: booth } = useGetBooth(waitingDetail?.boothID || 0);
+
   const { openModal } = useModal();
 
   console.log("wq:", waitingDetail);
@@ -93,7 +97,7 @@ const WaitingDetailPage = () => {
 
       {/* 나머지 부분은 그대로 유지 */}
       {/* <S.WaitingDetailRestWrapper show={true}> */}
-      <WaitingDetailMap />
+      {booth && <BoothLocationMap booth={booth} />}
       <Separator />
       <WaitingDetailCaution />
       {/* </S.WaitingDetailRestWrapper> */}


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용

진짜 드디어 UI와 일치하게 뷰를 짜고 자연스러운 UX를 지도에 적용했어요...

<!-- 작업한 내용을 적어주세요. -->

## 🚨 참고 사항

- 우선 부스 상세에서 네이버지도 (기본 제공 이미지)가 모달 위에 올라가는 이슈 (@ohchanju3 #48 문제는) 조건부 렌더링으로 우선 처리했습니다.
- 기존 컴포넌트를 그대로 가져고 싶었지만, 같은 path에서 자식이 "list", "map"이 분기된 상태인데 현재 이와 연관된 로직들이 부모 요소에서 관리되고, 연쇄적으로 자식 컴포넌트를 리렌더링을 시켜, 서드파티 라이브러리인 naver map과 결합성이 좋지 않았습니다. (ux 효과 저하) 따라서 map을 사용하는 컴포넌트 하위에 다시 (refetch, location, festival, switch)를 두어 상태를 관리했고, map에서 props drilling을 최소화 하는 방향으로 구현했습니다. 

## 📸 스크린샷

| 구현 내용 |           Mobile           |  
| :-------: | :-------------------------: | 
|    GIF    | <video src = "https://github.com/user-attachments/assets/19953f2c-87ae-4335-8154-e282b650cb25" width ="250"> |




## 🖥️ 주요 코드 설명

- 코드는 너무 못 짜서 코리 질문으로 받을게요..ㅠㅠㅎㅎ
- 혹시 쿼리키는 이런 식으로 바로 넘기는 방식 말고 더 좋은 방식 있을까요? ㅠㅠ props로 하면 계속 typeError가 나오네요

## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 📟 관련 이슈

- Resolved: #69 
