### PR TITLE
[Fix] #82 - 지도 <-> 바텀시트 z-index 문제 해결

### DIFF
--- a/apps/service/src/components/bottomButton/BottomButton.styled.ts
+++ b/apps/service/src/components/bottomButton/BottomButton.styled.ts
@@ -22,7 +22,7 @@ export const BottomButtonWrapper = styled.section`
   box-shadow: 0px 0px 4px 4px rgba(26, 30, 39, 0.1);
 
   flex-direction: column;
-  z-index: 9999;
+  z-index: 100;
 `;
 
 export const BottomButtonInformationWrapper = styled.div`

--- a/apps/service/src/components/bottomButton/BottomButton.styled.ts
+++ b/apps/service/src/components/bottomButton/BottomButton.styled.ts
@@ -22,6 +22,7 @@ export const BottomButtonWrapper = styled.section`
   box-shadow: 0px 0px 4px 4px rgba(26, 30, 39, 0.1);
 
   flex-direction: column;
+  z-index: 9999;
 `;
 
 export const BottomButtonInformationWrapper = styled.div`

--- a/apps/service/src/components/bottomSheet/entering/SingleEnteringContent.tsx
+++ b/apps/service/src/components/bottomSheet/entering/SingleEnteringContent.tsx
@@ -27,7 +27,12 @@ const SingleEnteringContent = (props: Props) => {
       title="지금 입장해주세요!"
       description={`제한 시간 10분 내로 부스에 입장해주세요.\n입장하지 않으실 경우 반드시 입장 취소 버튼을 눌러주세요.\n입장 취소 없이 노쇼할 경우, 전체 부스 대기가 취소돼요.`}
       content={
-        <Flex direction="column" gap="0.75rem" padding="0 0 0.25rem 0">
+        <Flex
+          direction="column"
+          gap="0.75rem"
+          padding="0 0 0.25rem 0"
+          zIndex={101}
+        >
           {isWaiting && <NoticeCard />}
           {waiting && <WaitingDetailCard {...waiting} />}
         </Flex>

--- a/apps/service/src/components/infobottomButton/InfoBottomButton.styled.ts
+++ b/apps/service/src/components/infobottomButton/InfoBottomButton.styled.ts
@@ -11,7 +11,7 @@ export const InfoBottomButtonBackground = styled.div`
   top: 50%;
   left: 50%;
 
-  /* z-index: 0; */
+  z-index: 101;
 
   width: 100%;
   max-width: 540px;

--- a/apps/service/src/pages/boothDetail/BoothDetailPage.tsx
+++ b/apps/service/src/pages/boothDetail/BoothDetailPage.tsx
@@ -184,7 +184,7 @@ const BoothDetailPage = () => {
           <Separator height={8} />
 
           <BoothDetailMenu booth={booth} />
-          <div style={{ zIndex: 3 }}>
+          <div>
             <BottomButton
               informationTitle={getInformationTitle()}
               informationSub={getInformationSub()}

--- a/apps/service/src/pages/myWaiting/MyWaiting.tsx
+++ b/apps/service/src/pages/myWaiting/MyWaiting.tsx
@@ -12,7 +12,6 @@ const MyWaitingPage = () => {
     direction: "column",
     gap: "0.5rem",
     padding: "1.25rem 1rem 1.75rem 1rem",
-    zIndex: 9999,
   };
 
   const queries = [["need_values"]];

--- a/apps/service/src/pages/myWaiting/MyWaiting.tsx
+++ b/apps/service/src/pages/myWaiting/MyWaiting.tsx
@@ -12,6 +12,7 @@ const MyWaitingPage = () => {
     direction: "column",
     gap: "0.5rem",
     padding: "1.25rem 1rem 1.75rem 1rem",
+    zIndex: 9999,
   };
 
   const queries = [["need_values"]];

--- a/packages/core/src/components/bottomSheet/BottomSheetProvider.tsx
+++ b/packages/core/src/components/bottomSheet/BottomSheetProvider.tsx
@@ -20,7 +20,7 @@ const BottomSheetProvider = () => {
   return (
     <FixedContainer
       justifyContent="end"
-      zIndex={10}
+      zIndex={101}
       closeContainer={closeBottomSheet}
     >
       <BottomSheet {...content} />

--- a/packages/core/src/components/flex/Flex.styled.ts
+++ b/packages/core/src/components/flex/Flex.styled.ts
@@ -16,4 +16,5 @@ export const getFlexStyle = (style: FlexStyle) => css`
   overflow: ${style.overflow};
 
   padding: ${style.padding};
+  z-index: ${style.zIndex};
 `;

--- a/packages/core/src/components/flex/Flex.tsx
+++ b/packages/core/src/components/flex/Flex.tsx
@@ -11,6 +11,7 @@ export type FlexStyle = {
   justifyContent?: "center" | "start" | "end" | "space-between";
   overflow?: "visible" | "hidden" | "scroll";
   padding?: string;
+  zIndex?: number | "auto";
 };
 
 export type FlexProps<T extends React.ElementType> = {
@@ -31,7 +32,7 @@ const Flex = <T extends React.ElementType>(props: FlexProps<T>) => {
     justifyContent = "start",
     overflow = "hidden",
     padding = "0rem",
-
+    zIndex = "auto",
     ...attributes
   } = props;
 
@@ -51,6 +52,7 @@ const Flex = <T extends React.ElementType>(props: FlexProps<T>) => {
           justifyContent,
           overflow,
           padding,
+          zIndex,
         }),
       ]}
       {...attributes}

--- a/packages/core/src/components/modal/ModalProvider.tsx
+++ b/packages/core/src/components/modal/ModalProvider.tsx
@@ -21,7 +21,7 @@ const ModalProvider = () => {
     return (
       <FixedContainer
         justifyContent="center"
-        zIndex={20}
+        zIndex={102}
         closeContainer={closeModal}
       >
         <Modal {...props} />


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용

기존 지도의 특정 아이콘이 바텀시트 위에 올라오는 에러를 해결했습니다.

## 🚨 참고 사항

높이가 있는 바텀시트 컴포넌트에 ```z-index: 9999;```를 부여했습니다.

## 📸 스크린샷


## 🖥️ 주요 코드 설명


`Flex`

- 특정 BottomSheet가 Flex를 사용해서 해당 컴포넌트 선택인자로 zIndex를 추가했습니다!

```typescript
export type FlexStyle = {
  width?: "100%" | "auto" | string;
  height?: string;
  flexGrow?: 0 | 1;
  flexShrink?: 0 | 1;
  gap?: string;
  direction?: "column" | "row";
  alignItem?: "center" | "start" | "end" | "stretch";
  justifyContent?: "center" | "start" | "end" | "space-between";
  overflow?: "visible" | "hidden" | "scroll";
  padding?: string;
  zIndex?: number | "auto";
};

```

## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 📟 관련 이슈

- Resolved: #82 
