### PR TITLE
[Fix] #90 - 지도 뷰 Chrome, Safari 모바일 환경에서 바텀시트 대응

### DIFF
--- a/apps/service/public/icons/icon_checkBox_before.svg
+++ b/apps/service/public/icons/icon_checkBox_before.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="0.5" y="0.5" width="23" height="23" rx="3.5" stroke="#E2E6EF"/>
+</svg>

--- a/apps/service/src/pages/main/_components/mainNavigation/MainNavigation.styled.ts
+++ b/apps/service/src/pages/main/_components/mainNavigation/MainNavigation.styled.ts
@@ -23,7 +23,7 @@ export const getWrapper = (type: MainViewType, isFold: boolean) => {
     const getMapStyle =
       type === "map" &&
       css`
-        height: 100vh;
+        height: 100dvh;
         background-color: transparent;
       `;
 

--- a/apps/service/src/pages/main/_components/map/MainMap.styled.ts
+++ b/apps/service/src/pages/main/_components/map/MainMap.styled.ts
@@ -11,7 +11,7 @@ export const getWrapper = () => css`
   top: calc(13rem);
   z-index: 1;
 
-  height: calc(100vh - 13rem - 4.75rem);
+  height: calc(100dvh - 13rem - 4.75rem);
 `;
 
 export const getButtonStyle = () => css`
@@ -20,7 +20,7 @@ export const getButtonStyle = () => css`
 
 export const getFloatingButtonWrapperStyle =
   (viewType: MainViewType) => (theme: Theme) => {
-    const getBottom = viewType === "list" ? "1rem" : "4rem";
+    const getBottom = viewType === "list" ? "2rem" : "4rem";
     return css`
       /* main page의 header 보다 위에 */
       z-index: 2;


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용

iOS(아이폰) Chrome, Safari 환경에서 Map 바텀시트가 제대로 작동하지 않아 이를 수정했습니다.

## 🚨 참고 사항

map을 다루는 부분 viewport를 100dvh로 정의했습니다.

[참고 아티클
](https://velog.io/@freejak5520/iOS-%EB%B8%8C%EB%9D%BC%EC%9A%B0%EC%A0%80%EC%97%90%EC%84%9C%EC%9D%98-%EB%B7%B0%ED%8F%AC%ED%8A%B8-%EB%86%92%EC%9D%B4-%EB%AC%B8%EC%A0%9C%EC%99%80-%ED%95%B4%EA%B2%B0-%EB%B0%A9%EB%B2%95)

## 📸 스크린샷
<img src="https://github.com/user-attachments/assets/e8126086-4497-4147-9693-db82826561cf" width="250px"/>


## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. -->


- 수정 부분

```ts
export const getWrapper = () => css`
  z-index: 1;
  width: 100%;
  overflow: hidden;

  position: absolute;
  top: calc(13rem);
  z-index: 1;

  height: calc(100dvh - 13rem - 4.75rem);
`;
```


```typescript
 const getMapStyle =
      type === "map" &&
      css`
        height: 100dvh;
        background-color: transparent;
      `;
```

## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 📟 관련 이슈

- Resolved: #90 
