### PR TITLE
[Fix] #96 - 지도 부스카드 이전 상태 포커스 문제 해결

### DIFF
--- a/apps/service/src/components/boothLocationMap/BoothLocationMap.tsx
+++ b/apps/service/src/components/boothLocationMap/BoothLocationMap.tsx
@@ -9,6 +9,7 @@ import { useToast } from "@linenow/core/hooks";
 import { useSetAtom } from "jotai";
 import { latLngAtom } from "@atoms/location";
 import { ROUTE } from "@constants/route";
+import { selectedBoothAtom } from "@pages/main/_atom/selectedBooth";
 
 interface BoothLocationContentProps {
   booth: Booth;
@@ -18,10 +19,12 @@ export const BoothLocationMap = ({ booth }: BoothLocationContentProps) => {
   const mapRef = useRef<null | HTMLDivElement>(null);
   const navigate = useNavigate();
   const setLatLng = useSetAtom(latLngAtom);
+  const setBooth = useSetAtom(selectedBoothAtom);
   const { setViewType } = useMainViewType();
 
   const { presentToast } = useToast();
   useSmallNaverMap(mapRef, booth);
+
   return (
     <S.BoothLocationMapWrapper>
       <Label font="head3" color="black" css={[S.getTitleLabelStyle()]}>
@@ -32,11 +35,12 @@ export const BoothLocationMap = ({ booth }: BoothLocationContentProps) => {
         <S.BoothLocationMapClickableBar
           onClick={() => {
             setViewType("map");
-            navigate(ROUTE.DEFAULT, { state: booth.boothID });
+            setBooth(booth.boothID);
             setLatLng({
               lat: Number(booth.latitude),
               lng: Number(booth.longitude),
             });
+            navigate(ROUTE.DEFAULT);
           }}
         >
           클릭해서 지도 보기

--- a/apps/service/src/pages/main/MainPage.tsx
+++ b/apps/service/src/pages/main/MainPage.tsx
@@ -16,8 +16,6 @@ import { Switch } from "@linenow/core/components";
 import * as S from "./MainPage.styled";
 import MainNavigation from "./_components/mainNavigation/MainNavigation";
 import MainBoothListHeader from "./_components/boothList/MainBoothListHeader";
-import { useAtomValue } from "jotai";
-import { isSelectedBoothAtom } from "./_atom/selectedBooth";
 
 const MainPage = () => {
   const { viewType, mainViewTypeSwitchProps } = useMainViewType();
@@ -27,8 +25,6 @@ const MainPage = () => {
 
   // refetch queries
   const { queries } = isLogin ? useGetMainDataUser() : useGetMainDataGuest();
-  const selectedBoothStatus = useAtomValue(isSelectedBoothAtom);
-  console.log(selectedBoothStatus);
 
   return (
     <>

--- a/apps/service/src/pages/main/_atom/selectedBooth.tsx
+++ b/apps/service/src/pages/main/_atom/selectedBooth.tsx
@@ -1,3 +1,3 @@
 import { atom } from "jotai";
 
-export const isSelectedBoothAtom = atom<boolean>(false);
+export const selectedBoothAtom = atom<number | null>(null);

--- a/apps/service/src/pages/main/_components/boothList/MainBoothList.tsx
+++ b/apps/service/src/pages/main/_components/boothList/MainBoothList.tsx
@@ -2,6 +2,8 @@ import { BoothThumbnailBadgeProps } from "@components/booth/BoothThumbnailBadge"
 import * as S from "./MainBoothList.styled";
 
 import MainBoothListItem from "./MainBoothListItem";
+import { useSetAtom } from "jotai";
+import { selectedBoothAtom } from "@pages/main/_atom/selectedBooth";
 
 interface MainBoothListProps {
   booths: BoothThumbnailBadgeProps[];
@@ -9,7 +11,8 @@ interface MainBoothListProps {
 
 const MainBoothList = (props: MainBoothListProps) => {
   const { booths } = props;
-
+  const setBoothNull = useSetAtom(selectedBoothAtom);
+  setBoothNull(null);
   // 리스트가 비어있을 경우
   if (booths.length === 0) return;
 

--- a/apps/service/src/pages/main/_components/map/MainMap.tsx
+++ b/apps/service/src/pages/main/_components/map/MainMap.tsx
@@ -1,21 +1,19 @@
 import * as S from "./MainMap.styled";
 
 import { BoothPinProps, useNaverMap } from "@pages/main/_hooks/useNaverMap";
-import { memo, useRef, useState } from "react";
+import { memo, useRef } from "react";
 import { SelectedBoothCard } from "./MainSelectedBoothCard";
-import { useLocation } from "react-router-dom";
+import { useAtom } from "jotai";
+import { selectedBoothAtom } from "@pages/main/_atom/selectedBooth";
 
 interface MainMapProps {
   booths: BoothPinProps[];
 }
 const MainMap = memo((props: MainMapProps) => {
   const { booths } = props;
-  const location = useLocation();
 
   const selectedBoothIdRef = useRef<number | null>(null);
-  const [selectedBoothId, setSelectedBoothId] = useState<number | null>(
-    location.state || null
-  );
+  const [selectedBoothId, setSelectedBoothId] = useAtom(selectedBoothAtom);
 
   const safeSetSelectedBoothId = (id: number | null) => {
     selectedBoothIdRef.current = id;


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용

<img width="675" alt="image" src="https://github.com/user-attachments/assets/3fb3fe14-8546-484a-94c4-24abad497503" />


<!-- 참고할 사항이 있다면 적어주세요. -->



## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. -->

선택 부스를 navigation 상태로 넘기는 기존 방식에서 전역 상태 관리를 선택했습니다.


```ts
export const selectedBoothAtom = atom<number | null>(null);
```

해당 Atom을 통해 `BoothLocationMap`에서 아래와 같이 onClick 시 로직을 수정했습니다.

```ts
<S.BoothLocationMapClickableBar
          onClick={() => {
            setViewType("map");
            setBooth(booth.boothID);
            setLatLng({
              lat: Number(booth.latitude),
              lng: Number(booth.longitude),
            });
            navigate(ROUTE.DEFAULT);
          }}
 />
```

또 `MainBoothList`에서 null로 설정해 map에서 이탈 시 선택을 해제했습니다.

```typescript

const setBoothNull = useSetAtom(selectedBoothAtom);
setBoothNull(null);

```

## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 📟 관련 이슈

- Resolved: #96 
