### PR TITLE
[Fix]#98-로그인 후 스피너, api get 지속 요청 방지

### DIFF
--- a/apps/admin/src/components/sidebar/Sidebar.tsx
+++ b/apps/admin/src/components/sidebar/Sidebar.tsx
@@ -18,7 +18,7 @@ import {
 import { useEffect, useState } from "react";
 import useIsLoading from "@hooks/useIsLoading";
 import { usePostLogout } from "@hooks/apis/auth";
-import Spinner from "@components/spinner/Spinner";
+// import Spinner from "@components/spinner/Spinner";
 import {
   modalStartOperation,
   modalStartWaiting,
@@ -60,6 +60,8 @@ const Sidebar = ({ isMobile, isOpen, setIsOpen }: SidebarProps) => {
   }, [isLoadingLogout]);
 
   useEffect(() => {
+    if (boothLoading) return; // 👈 booth 상태 받아오기 전에는 아무것도 안함
+
     const fetchBoothStatus = async () => {
       const statusData = await getBoothRestartStatus();
       if (statusData) {
@@ -73,7 +75,7 @@ const Sidebar = ({ isMobile, isOpen, setIsOpen }: SidebarProps) => {
     };
 
     fetchBoothStatus();
-  }, [setShowOverlay]);
+  }, [boothLoading, setShowOverlay]); // 👈 boothLoading을 의존성으로 추가
 
   useEffect(() => {
     if (isRestart === false) {
@@ -215,9 +217,9 @@ const Sidebar = ({ isMobile, isOpen, setIsOpen }: SidebarProps) => {
   };
 
   const getButton = () => {
-    if (boothLoading) {
-      return <Spinner />;
-    }
+    // if (boothLoading) {
+    //   return <Spinner />;
+    // }
 
     switch (boothStatus) {
       case "operating":
@@ -237,21 +239,22 @@ const Sidebar = ({ isMobile, isOpen, setIsOpen }: SidebarProps) => {
     <>
       <S.SidebarWrapper>
         <S.SidebarUserInfoWapper>
-          {boothLoading ? (
+          {/* {
+          boothLoading ? (
             <Spinner />
-          ) : (
-            <>
-              <h3>안녕하세요</h3>
-              <h1>
-                <span className="lime">{auth?.adminUser.manager_name}</span> 님
-              </h1>
-              <CommonButton>
-                <S.SidebarLogout onClick={handleLogoutClick}>
-                  로그아웃
-                </S.SidebarLogout>
-              </CommonButton>
-            </>
-          )}
+          ) : ( */}
+          <>
+            <h3>안녕하세요</h3>
+            <h1>
+              <span className="lime">{auth?.adminUser.manager_name}</span> 님
+            </h1>
+            <CommonButton>
+              <S.SidebarLogout onClick={handleLogoutClick}>
+                로그아웃
+              </S.SidebarLogout>
+            </CommonButton>
+          </>
+          {/* )} */}
         </S.SidebarUserInfoWapper>
 
         {/* 대기 팀 관리, 문의하기  */}

--- a/apps/admin/src/components/sidebar/Sidebar.tsx
+++ b/apps/admin/src/components/sidebar/Sidebar.tsx
@@ -60,7 +60,7 @@ const Sidebar = ({ isMobile, isOpen, setIsOpen }: SidebarProps) => {
   }, [isLoadingLogout]);
 
   useEffect(() => {
-    if (boothLoading) return; // 👈 booth 상태 받아오기 전에는 아무것도 안함
+    if (boothLoading) return;
 
     const fetchBoothStatus = async () => {
       const statusData = await getBoothRestartStatus();
@@ -75,7 +75,7 @@ const Sidebar = ({ isMobile, isOpen, setIsOpen }: SidebarProps) => {
     };
 
     fetchBoothStatus();
-  }, [boothLoading, setShowOverlay]); // 👈 boothLoading을 의존성으로 추가
+  }, [boothLoading, setShowOverlay]);
 
   useEffect(() => {
     if (isRestart === false) {

--- a/apps/admin/src/hooks/apis/auth.ts
+++ b/apps/admin/src/hooks/apis/auth.ts
@@ -37,6 +37,9 @@ export const usePostLogin = () => {
     mutationKey: ["auth_login"],
     mutationFn: (requestBody: UsePostLoginProps) =>
       postLogin({ manager_code: requestBody.adminCode }),
+    onMutate: () => {
+      setLoadings({ isFullLoading: true }); // 로그인 요청 시작 시 로딩 시작
+    },
     onSuccess: async (response: LoginResponse) => {
       login({
         accessToken: response.access,

--- a/apps/admin/src/hooks/apis/booth.ts
+++ b/apps/admin/src/hooks/apis/booth.ts
@@ -7,5 +7,8 @@ export const useGetWaitings = (status: WaitingStatusParams) => {
   return useQuery({
     queryKey: [BOOTH_QUERY_KEY.WAITINGS, status],
     queryFn: () => getWaitings(status),
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    retry: 1,
   });
 };

--- a/apps/admin/src/hooks/apis/boothManaging.ts
+++ b/apps/admin/src/hooks/apis/boothManaging.ts
@@ -36,7 +36,10 @@ export const usePostWaitingAction = () => {
 export const useGetBoothStatus = () => {
   return useQuery({
     queryKey: [BOOTH_MANAGING_QUERY_KEY.BOOTH_STATUS, "boothInfo"],
-    queryFn: () => getBoothStatus(),
+    queryFn: getBoothStatus,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    retry: 1,
   });
 };
 
@@ -96,5 +99,7 @@ export const useGetWaitingsCounts = () => {
   return useQuery({
     queryKey: [BOOTH_MANAGING_QUERY_KEY.WAITINGS_COUNTS],
     queryFn: () => getWaitingsCounts(),
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
   });
 };

--- a/apps/admin/src/hooks/apis/boothManaging.ts
+++ b/apps/admin/src/hooks/apis/boothManaging.ts
@@ -101,5 +101,6 @@ export const useGetWaitingsCounts = () => {
     queryFn: () => getWaitingsCounts(),
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
+    retry: 1,
   });
 };

--- a/apps/admin/src/pages/login/LoginPage.tsx
+++ b/apps/admin/src/pages/login/LoginPage.tsx
@@ -12,6 +12,7 @@ const LoginPage = () => {
   const [inputValue, setInputValue] = useState("");
 
   const { mutate: postLogin } = usePostLogin();
+
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setInputValue(e.target.value);
   };


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용

<!-- 작업한 내용을 적어주세요. -->
- 로그인 후 응답이 올 때까지 spinner를 보여줍니다.
- booth api get 요청이 계속 호출되어서 방지합니다.

## 🚨 참고 사항

<!-- 참고할 사항이 있다면 적어주세요. -->

- 백에서 로그인 응답 최대한 빨리 한거라고 하는데, 로그인 응답이 오는데 약 7~10초정도 소요됩니다! 그래서 고유번호가 맞았거나 틀린 경우 모두 우선 응답이 올 때까지 7초 정도는 스피너가 보인다고 생각해주시면 됩니다.

- 찾아보니 리액트 쿼리 기본 속성에 
<img width="522" alt="스크린샷 2025-05-21 오후 8 56 20" src="https://github.com/user-attachments/assets/dbf62bae-fad8-4ba9-8262-1ddf23494248" />

이렇게 있다고 합니다. 그런데 소켓으로 인해 데이터가 계속 연동되고 왔다갔다?하면서 호출도 되고 탭을 바꾸고 다시 돌아올때마다 또 booth get이 되어서 

옵션 설정을

```typescript
refetchOnWindowFocus: false,
refetchOnReconnect: false,
retry: 1,
```

이렇게 해주었습니다.

## 📸 스크린샷


| 구현 내용 |           Desktop           |     
| :-------: | :-------------------------: | 
|    GIF    | <img src = "https://github.com/user-attachments/assets/cae593a8-3d19-4a83-a648-0d6f8aada746" width ="250"> | 

## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. -->

`booth.ts`

- 위 설명과 동일합니다.

```typescript
export const useGetWaitings = (status: WaitingStatusParams) => {
  return useQuery({
    queryKey: [BOOTH_QUERY_KEY.WAITINGS, status],
    queryFn: () => getWaitings(status),
    refetchOnWindowFocus: false,
    refetchOnReconnect: false,
    retry: 1,
  });
};
```

`boothManaging.ts`
```typescript
export const useGetBoothStatus = () => {
  return useQuery({
    queryKey: [BOOTH_MANAGING_QUERY_KEY.BOOTH_STATUS, "boothInfo"],
    queryFn: getBoothStatus,
    refetchOnWindowFocus: false,
    refetchOnReconnect: false,
    retry: 1,
  });
};
```

## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 📟 관련 이슈

- Resolved: #98
