### PR TITLE
[Fix]#98 소켓으로 받아오는 대기 카드 정렬

### DIFF
--- a/apps/admin/src/pages/main/utils/sortWaitings.ts
+++ b/apps/admin/src/pages/main/utils/sortWaitings.ts
@@ -1,0 +1,24 @@
+import { Waiting } from "@interfaces/waiting";
+
+const sortWaitings = (list: Waiting[]): Waiting[] => {
+  const statusOrder: Record<string, number> = {
+    entering: 0, // 입장 중
+    waiting: 1, // 대기 중
+    entered: 2, // 입장 완료
+    canceled: 3, // 취소
+    time_over: 3, // 시간 초과, 취소와 동일 순서
+  };
+
+  return [...list].sort((a, b) => {
+    const statusA = statusOrder[a.waitingStatus] ?? 999;
+    const statusB = statusOrder[b.waitingStatus] ?? 999;
+
+    if (statusA !== statusB) {
+      return statusA - statusB;
+    }
+
+    return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+  });
+};
+
+export default sortWaitings;


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용

<!-- 작업한 내용을 적어주세요. -->

- 소켓으로 받아오는 데이터를 순서에 맞게 정렬하는 함수를 만들어 적용했습니다.

## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. -->

`sortWaitings`

- 순서 정렬하는 함수

```typescript
import { Waiting } from "@interfaces/waiting";

const sortWaitings = (list: Waiting[]): Waiting[] => {
  const statusOrder: Record<string, number> = {
    entering: 0, // 입장 중
    waiting: 1, // 대기 중
    entered: 2, // 입장 완료
    canceled: 3, // 취소
    time_over: 3, // 시간 초과, 취소와 동일 순서
  };

  return [...list].sort((a, b) => {
    const statusA = statusOrder[a.waitingStatus] ?? 999;
    const statusB = statusOrder[b.waitingStatus] ?? 999;

    if (statusA !== statusB) {
      return statusA - statusB;
    }

    return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
  });
};

export default sortWaitings;

```

## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 📟 관련 이슈

- Resolved: #98
