### PR TITLE
[Fix]#109-관리자 대기 카드 정렬

### DIFF
--- a/apps/admin/src/pages/main/MainPages.tsx
+++ b/apps/admin/src/pages/main/MainPages.tsx
@@ -112,7 +112,7 @@ const MainPage = () => {
   };
   useEffect(() => {
     if (data) {
-      setWaitings(sortWaitings(data));
+      setWaitings(data);
     }
   }, [data]);
 

--- a/apps/admin/src/pages/main/utils/sortWaitings.ts
+++ b/apps/admin/src/pages/main/utils/sortWaitings.ts
@@ -4,9 +4,9 @@ const sortWaitings = (list: Waiting[]): Waiting[] => {
   const statusOrder: Record<string, number> = {
     entering: 0, // 입장 중
     waiting: 1, // 대기 중
-    entered: 2, // 입장 완료
-    canceled: 3, // 취소
-    time_over: 3, // 시간 초과, 취소와 동일 순서
+    canceled: 2, // 취소
+    time_over: 2, // 시간 초과
+    entered: 3, // 입장 완료
   };
 
   return [...list].sort((a, b) => {
@@ -17,7 +17,20 @@ const sortWaitings = (list: Waiting[]): Waiting[] => {
       return statusA - statusB;
     }
 
-    return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+    if (a.waitingStatus === "waiting" || a.waitingStatus === "entering") {
+      // 오래된 순
+      return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+    }
+
+    if (
+      a.waitingStatus === "entered" ||
+      a.waitingStatus === "canceled" ||
+      a.waitingStatus === "time_over"
+    ) {
+      // 최신 순
+      return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+    }
+    return 0;
   });
 };
 


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용

<!-- 작업한 내용을 적어주세요. -->

관리자 페이지에서 대기 카드 순서를 

1. 대기중/입장중 -> 여기는 오랜된 순
2. 취소된 대기 -> 여기는 최신 순
3. 입장 완료 -> 여기는 최신 순

이 순서대로 맞췄습니다.

api get해오는건 그대로 보여주고, 소켓 데이터 정렬에서 순서 변경사항이 있습니다.


## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 📟 관련 이슈

- Resolved: #109
