### PR TITLE
[Fix]#125-부스 디테일 메뉴 엔터 처리

### DIFF
--- a/apps/service/src/pages/boothDetail/_components/menu/BoothDetailMenu.styled.ts
+++ b/apps/service/src/pages/boothDetail/_components/menu/BoothDetailMenu.styled.ts
@@ -26,12 +26,13 @@ export const BoothDetailMenuArticleWrapper = styled.div`
   justify-content: space-between;
 
   width: 100%;
+  align-items: center;
 `;
 
 export const BoothDetailMenuArticle = styled.article`
   overflow: hidden;
   text-overflow: ellipsis;
-
+  white-space: pre-line;
   color: ${({ theme }) => theme.fontColors.blackLight};
   ${fonts.body2}
 `;


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용

<!-- 작업한 내용을 적어주세요. -->
메뉴가 엔터치도록 가능해져서
white-space: pre-line을 추가했고, 가격이 메뉴 이름 가운데 정렬되도록 했습니다.

## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 📟 관련 이슈

- #125
