### PR TITLE
[Fix]#125-대기 0팀일때 워딩 수정

### DIFF
--- a/apps/service/src/components/booth/getBadges.tsx
+++ b/apps/service/src/components/booth/getBadges.tsx
@@ -29,7 +29,9 @@ const getBadges = (params: GetBadgesParams) => {
       {waitingStatus === "waiting" && <Chip variant="blue">대기 중</Chip>}
       {waitingStatus === "entering" && <Chip variant="lime">입장 가능</Chip>}
       <Chip variant="blueLight">
-        {totalWaitingTeams === 0 ? `대기 없음` : `대기 ${totalWaitingTeams}팀`}
+        {totalWaitingTeams === 0
+          ? `빠른 입장 가능`
+          : `대기 ${totalWaitingTeams}팀`}
       </Chip>
     </>
   );


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용

<!-- 작업한 내용을 적어주세요. -->

대기 0팀일때의 워딩을 "빠른 입장 가능" 으로 수정

## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 📟 관련 이슈

- Resolved: #125
